### PR TITLE
Fix opencc version

### DIFF
--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -22,7 +22,7 @@ ftfy
 gdown
 inflect
 jieba
-opencc
+opencc==1.1.6
 pangu
 rapidfuzz
 pybind11

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ftfy
 gdown
 inflect
 jieba
-opencc
+opencc==1.1.6
 pangu
 rapidfuzz
 pybind11


### PR DESCRIPTION
The AMI used in the current ParallelCluster setup (https://github.com/aws-neuron/aws-neuron-parallelcluster-samples#train-a-model-on-aws-trn1-parallelcluster) comes with `libstdc++` supporting the following versions:

```bash
$ strings /lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
GLIBCXX_3.4
GLIBCXX_3.4.1
GLIBCXX_3.4.2
GLIBCXX_3.4.3
GLIBCXX_3.4.4
GLIBCXX_3.4.5
GLIBCXX_3.4.6
GLIBCXX_3.4.7
GLIBCXX_3.4.8
GLIBCXX_3.4.9
GLIBCXX_3.4.10
GLIBCXX_3.4.11
GLIBCXX_3.4.12
GLIBCXX_3.4.13
GLIBCXX_3.4.14
GLIBCXX_3.4.15
GLIBCXX_3.4.16
GLIBCXX_3.4.17
GLIBCXX_3.4.18
GLIBCXX_3.4.19
GLIBCXX_3.4.20
GLIBCXX_3.4.21
GLIBCXX_3.4.22
GLIBCXX_3.4.23
GLIBCXX_3.4.24
GLIBCXX_3.4.25
GLIBCXX_3.4.26
GLIBCXX_3.4.27
GLIBCXX_3.4.28
GLIBCXX_DEBUG_MESSAGE_LENGTH
```

opencc library recently released 1.1.7 (https://github.com/BYVoid/OpenCC/releases/tag/ver.1.1.7) which requires `GLIBCXX_3.4.29`. 

This causes the following error when we build the Megatron helper module:

```bash
$ python3 -c “from nemo.collections.nlp.data.language_modeling.megatron.dataset_utils import compile_helper; \
compile_helper()”
2023-Oct-16 17:21:42.0036 13304:13304 ERROR TDRV:tdrv_get_dev_info           No neuron device available
[NeMo W 2023-10-16 17:21:43 optimizers:70] Could not import distributed_fused_adam optimizer fromApex
WARNING:matplotlib.font_manager:Matplotlib is building the font cache; this may take a moment.
[NeMo W 2023-10-16 17:21:55 experimental:27] Module <class'nemo.collections.nlp.data.language_modeling.megatron.megatron_batch_samplers.MegatronPretrainingRandomBatchSampler'> is experimental, not ready for production and is not fully supported. Use at your own risk.
Traceback (most recent call last):
 File "<string>", line 1, in <module>
 File "/home/ubuntu/aws_neuron_venv_pytorch/lib/python3.8/site-packages/nemo/collections/nlp/__init__.py", line 15, in <module>
   from nemo.collections.nlp import data, losses, models, modules
 File "/home/ubuntu/aws_neuron_venv_pytorch/lib/python3.8/site-packages/nemo/collections/nlp/models/__init__.py", line 31, in <module>
   from nemo.collections.nlp.models.machine_translation import MTEncDecModel
 File "/home/ubuntu/aws_neuron_venv_pytorch/lib/python3.8/site-packages/nemo/collections/nlp/models/machine_translation/__init__.py", line 15, in <module>
   from nemo.collections.nlp.models.machine_translation.mt_enc_dec_bottleneck_model importMTBottleneckModel
 File "/home/ubuntu/aws_neuron_venv_pytorch/lib/python3.8/site-packages/nemo/collections/nlp/models/machine_translation/mt_enc_dec_bottleneck_model.py", line 23,in <module>
   from nemo.collections.nlp.models.machine_translation.mt_enc_dec_model import MTEncDecModel
 File "/home/ubuntu/aws_neuron_venv_pytorch/lib/python3.8/site-packages/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py", line 37, in <module>
   from nemo.collections.common.tokenizers.chinese_tokenizers import ChineseProcessor
 File "/home/ubuntu/aws_neuron_venv_pytorch/lib/python3.8/site-packages/nemo/collections/common/tokenizers/chinese_tokenizers.py", line 38, in <module>
   import opencc
 File "/home/ubuntu/aws_neuron_venv_pytorch/lib/python3.8/site-packages/opencc/__init__.py", line 6, in <module>
   from opencc.clib import opencc_clib
ImportError: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /home/ubuntu/aws_neuron_venv_pytorch/lib/python3.8/site-packages/opencc/clib/opencc_clib.cpython-38-x86_64-linux-gnu.so)

```

This PR is proposing to fix opencc version to 1.1.6 until the PCluster AMI starts supporting `GLIBCXX_3.4.29`.