### PR TITLE
Adds support for BigCode model family

### DIFF
--- a/nemo/examples/nlp/language_modeling/checkpoint_conversion/convert_hf_checkpoint_to_nemo_bigcode.py
+++ b/nemo/examples/nlp/language_modeling/checkpoint_conversion/convert_hf_checkpoint_to_nemo_bigcode.py
@@ -1,0 +1,274 @@
+import argparse
+import json
+from pathlib import Path
+import numpy as np
+import torch
+import os
+import glob
+from transformers import AutoTokenizer
+
+
+def fix_query_key_value_ordering(
+        param, checkpoint_version, num_splits, num_heads, hidden_size
+):
+    # Permutes layout of param tensor to [num_splits * num_heads * hidden_size, :]
+    # for compatibility with later versions of NVIDIA Megatron-LM.
+    # The inverse operation is performed inside Megatron-LM to read checkpoints:
+    # https://github.com/NVIDIA/Megatron-LM/blob/v2.4/megatron/checkpointing.py#L209
+    # If param is the weight tensor of the self-attention block, the returned tensor
+    # will have to be transposed one more time to be read by HuggingFace GPT2.
+    input_shape = param.size()
+    if checkpoint_version == 1.0:
+        # version 1.0 stores [num_heads * hidden_size * num_splits, :]
+        saved_shape = (num_heads, hidden_size, num_splits) + input_shape[1:]
+        param = param.view(*saved_shape)
+        param = param.transpose(0, 2)
+        param = param.transpose(1, 2).contiguous()
+    elif checkpoint_version >= 2.0:
+        # other versions store [num_heads * num_splits * hidden_size, :]
+        saved_shape = (num_splits, num_heads, hidden_size) + input_shape[1:]
+        param = param.view(*saved_shape)
+        param = param.transpose(0, 1).contiguous()
+    param = param.view(*input_shape)
+    return param
+
+
+def pad_to_vocab_size_and_tp(param, tokenizer_vocab_size, tp, make_vocab_size_divisible_by):
+    # pad vocab size to match that of tokenizer
+    if tokenizer_vocab_size > param.shape[0]:
+        v_padded = torch.nn.functional.pad(
+            param, (0, 0, 0, (tokenizer_vocab_size - param.shape[0]))
+        )
+        print(
+            f"Padding vocab weights to {tokenizer_vocab_size} (so it matches the tokenizer vocab size). Added tokens {(tokenizer_vocab_size - param.shape[0])}")
+        print(f"Shape before {param.shape} Padded shape {v_padded.shape}")
+    else:
+        v_padded = param
+
+    # Padding to make it divisble by make_vocab_size_divisible_by and TP degree
+    multiple = make_vocab_size_divisible_by * tp
+    if v_padded.shape[0] % multiple > 0:
+        x = torch.nn.functional.pad(
+            v_padded, (0, 0, 0, (multiple - v_padded.shape[0] % multiple))
+        )
+        print(
+            f'Padding vocab to make it divisible by args.make_vocab_size_divisible_by * TP. Padded size {x.shape[0]}')
+    else:
+        x = param
+
+    return x
+
+
+def convert_checkpoint(p):
+    tokenizer = AutoTokenizer.from_pretrained(args.path_to_tokenizer)
+    tokenizer_vocab_size = len(tokenizer)
+
+    with open(args.config_file, "r") as f:
+        config = json.load(f)
+    print(config)
+
+    br_key = "h."  # Used to filter all transformer layers except layernorm
+
+    translation = {
+        "model.language_model.embedding.word_embeddings.weight": (1, "transformer.wte.weight", 0, 0),
+        "model.language_model.embedding.position_embeddings.weight": (0, "transformer.wpe.weight", None, 0),
+        "input_layernorm.weight": (0, "ln_1.weight", None, 0),
+        "input_layernorm.bias": (0, "ln_1.bias", None, 0),
+        "self_attention.dense.weight": (1, "attn.c_proj.weight", 1, 0),
+        "self_attention.dense.bias": (0, "attn.c_proj.bias", None, 0),
+        "post_attention_layernorm.weight": (0, "ln_2.weight", None, 0),
+        "post_attention_layernorm.bias": (0, "ln_2.bias", None, 0),
+        "mlp.dense_h_to_4h.weight": (1, "mlp.c_fc.weight", 0, 0),
+        "mlp.dense_h_to_4h.bias": (1, "mlp.c_fc.bias", 0, 0),
+        "mlp.dense_4h_to_h.weight": (1, "mlp.c_proj.weight", 1, 0),
+        "mlp.dense_4h_to_h.bias": (0, "mlp.c_proj.bias", None, 0),
+        "self_attention.query.weight": (1, "attn.c_attn_q.weight", 0, 0),
+        "self_attention.query.bias": (1, "attn.c_attn_q.bias", 0, 0),
+        "self_attention.key_value.weight": (0, "attn.c_attn_kv.weight", 0, 0),
+        "self_attention.key_value.bias": (0, "attn.c_attn_kv.bias", 0, 0),
+        "model.language_model.encoder.final_layernorm.weight": (0, "transformer.ln_f.weight", None, 0),
+        "model.language_model.encoder.final_layernorm.bias": (0, "transformer.ln_f.bias", None, 0),
+        "model.language_model.output_layer.weight": (1, "lm_head.weight", 0, 0),
+    }
+
+    reverse_translation = {}
+    for k, v in translation.items():
+        split, br_k, dim, transpose = v
+        reverse_translation[br_k] = (split, k, dim, transpose)
+
+    TP = args.tp_degree
+    PP = args.pp_degree
+    model_paths = sorted(
+        glob.glob(f'{args.path_to_checkpoint}/pytorch_model*.bin'))
+
+    model_bigcode = {}
+    for _path in model_paths:
+        print(f'Loading {_path}')
+        ts = torch.load(_path, map_location='cpu')
+        model_bigcode.update(ts)
+    print(len(model_bigcode))
+
+    print("Loaded BigCode model")
+
+    # Split Q and KV
+    for i in range(config['n_layer']):
+        q_weight = model_bigcode[f'transformer.h.{i}.attn.c_attn.weight'][:config['n_embd'], :]
+        kv_weight = model_bigcode[f'transformer.h.{i}.attn.c_attn.weight'][config['n_embd']:, :]
+
+        q_bias = model_bigcode[f'transformer.h.{i}.attn.c_attn.bias'][:config['n_embd']]
+        kv_bias = model_bigcode[f'transformer.h.{i}.attn.c_attn.bias'][config['n_embd']:]
+
+        model_bigcode[f'transformer.h.{i}.attn.c_attn_q.weight'] = q_weight.clone(
+        )
+        model_bigcode[f'transformer.h.{i}.attn.c_attn_kv.weight'] = kv_weight.clone(
+        )
+        model_bigcode[f'transformer.h.{i}.attn.c_attn_q.bias'] = q_bias.clone()
+        model_bigcode[f'transformer.h.{i}.attn.c_attn_kv.bias'] = kv_bias.clone(
+        )
+        model_bigcode.pop(f'transformer.h.{i}.attn.c_attn.weight')
+        model_bigcode.pop(f'transformer.h.{i}.attn.c_attn.bias')
+
+    for p in range(PP):
+        for i in range(TP):
+            print(f"=== PP {p}, TP {i} ===")
+            nemo_model = {}
+            for k, v in model_bigcode.items():
+                print(f">>> {k}")
+                if br_key in k:
+                    parts = k.split(br_key)[1].split(".")
+                    layer_number = parts[0]
+                    if int(layer_number) >= (config["n_layer"] // PP) * (p + 1) or int(layer_number) < (
+                            config["n_layer"] // PP) * p:
+                        continue
+                    k = ".".join(parts[1:])
+                    split, key, dim, tranpose = reverse_translation[k]
+                    layer_number = layer_number if PP == 1 else str(
+                        int(layer_number) % (config["n_layer"] // PP))
+                    key = "model.language_model.encoder.layers." + layer_number + "." + key
+                    nemo_model[key] = v
+                    print(nemo_model[key].shape)
+                    if tranpose:
+                        nemo_model[key] = torch.transpose(
+                            nemo_model[key], 0, 1
+                        )
+
+                    if "query" in key:
+                        heads = config["n_head"]
+                        hidden_size_per_head = config["n_embd"] // heads
+                        nemo_model[key] = fix_query_key_value_ordering(
+                            nemo_model[key], 2.0, 1, heads, hidden_size_per_head
+                        )
+                    elif "key_value" in key:
+                        heads = config["n_head"]
+                        hidden_size_per_head = config["n_embd"] // heads
+                        nemo_model[key] = fix_query_key_value_ordering(
+                            nemo_model[key], 2.0, 2, 1, hidden_size_per_head
+                        )
+
+                    if split:
+                        print(key, nemo_model[key].shape, dim)
+                        tp_last_dim_size = nemo_model[key].shape[dim] // TP
+                        if dim:  # First or last dimension to shard
+                            nemo_model[key] = nemo_model[key][
+                                ..., i * tp_last_dim_size: (i + 1) * tp_last_dim_size
+                            ].clone()
+                        else:
+                            nemo_model[key] = nemo_model[key][
+                                i * tp_last_dim_size: (i + 1) * tp_last_dim_size, ...
+                            ].clone()
+
+                    print(key, split, nemo_model[key].shape, v.shape)
+                else:
+                    split, key, dim, transpose = reverse_translation[k]
+                    if "wte" in k and p == 0:
+                        assert tokenizer_vocab_size >= v.shape[0]
+                        x = pad_to_vocab_size_and_tp(
+                            v, tokenizer_vocab_size, TP, args.make_vocab_size_divisible_by)
+                        last_dim_size = x.shape[0]
+                        tp_last_dim_size = last_dim_size // TP
+                        nemo_model[key] = x[
+                            i * tp_last_dim_size: (i + 1) * tp_last_dim_size, ...
+                        ].clone()
+                        print(key, split,
+                              nemo_model[key].shape, v.shape, x.shape)
+                    elif "wpe" in k and p == 0:
+                        nemo_model[key] = v.clone()
+                        print(key, split, nemo_model[key].shape, v.shape)
+                    elif "ln_f" in k and p == (PP - 1):
+                        nemo_model[key] = v
+                        print(key, split, nemo_model[key].shape, v.shape)
+                    elif "lm_head" in k and p == (PP - 1):  # Not used
+                        x = pad_to_vocab_size_and_tp(
+                            v, tokenizer_vocab_size, TP, args.make_vocab_size_divisible_by)
+                        if split:
+                            tp_last_dim_size = x.shape[dim] // TP
+                            if dim:
+                                nemo_model[key] = x[..., i *
+                                                    tp_last_dim_size:(i + 1) * tp_last_dim_size].clone()
+                            else:
+                                nemo_model[key] = x[i * tp_last_dim_size:(
+                                    i + 1) * tp_last_dim_size, ...].clone()
+                        print(key, split, nemo_model[key].shape, v.shape)
+
+            out_model = {"state_dict": nemo_model,
+                         'pytorch-lightning_version': '1.9.5', 'epoch': 0, 'global_step': 0}
+
+            output_folder = args.output_path
+            if TP > 1:
+                if PP > 1:
+                    output_folder = output_folder + f"/tp_rank_{i:02d}"
+                else:
+                    output_folder = output_folder + f"/mp_rank_{i:02d}"
+            if PP > 1:
+                output_folder = output_folder + f"_pp_rank_{p:03d}"
+            if not os.path.exists(output_folder):
+                os.makedirs(output_folder)
+            torch.save(out_model,
+                       f"{output_folder}/model_optim_rng.ckpt")  # , (not master_only), global_master=True)
+            print("Done saving Megatron checkpoint")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--checkpoint_version", default=2.0)
+    parser.add_argument(
+        "--path_to_checkpoint",
+        type=str,
+        help="Path to the checkpoint file (.zip archive or direct .pt file)",
+    )
+    parser.add_argument(
+        "--path_to_tokenizer",
+        type=str,
+        help="Path to the tokenizer",
+    )
+    parser.add_argument(
+        "--config_file",
+        type=str,
+        help="An optional config json file describing the pre-trained model.",
+    )
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        help="output path",
+    )
+    parser.add_argument(
+        "--tp_degree",
+        default=8,
+        type=int,
+        help="Tensor parallelism",
+    )
+    parser.add_argument(
+        "--pp_degree",
+        default=2,
+        type=int,
+        help="Pipeline parallelism",
+    )
+    parser.add_argument(
+        "--make_vocab_size_divisible_by",
+        default=8,
+        type=int,
+        help="Make vocab size divisible by (this has to match the config used in your model)",
+    )
+
+    args = parser.parse_args()
+    convert_checkpoint(args)

--- a/nemo/examples/nlp/language_modeling/checkpoint_conversion/convert_nemo_checkpoint_to_hf_bigcode.py
+++ b/nemo/examples/nlp/language_modeling/checkpoint_conversion/convert_nemo_checkpoint_to_hf_bigcode.py
@@ -1,0 +1,273 @@
+import os
+import argparse
+import json
+from pathlib import Path, PurePath
+from os.path import join
+from glob import glob
+import re
+import numpy as np
+import torch
+import torch_xla.utils.serialization as xser
+
+
+def fix_query_key_value_ordering(param, checkpoint_version, num_splits, num_heads, hidden_size):
+    # Permutes layout of param tensor to [num_splits * num_heads * hidden_size, :]
+    # for compatibility with later versions of NVIDIA Megatron-LM.
+    # The inverse operation is performed inside Megatron-LM to read checkpoints:
+    # https://github.com/NVIDIA/Megatron-LM/blob/v2.4/megatron/checkpointing.py#L209
+    # If param is the weight tensor of the self-attention block, the returned tensor
+    # will have to be transposed one more time to be read by HuggingFace GPT2.
+    input_shape = param.size()
+    if checkpoint_version == 1.0:
+        # version 1.0 stores [num_heads * hidden_size * num_splits, :]
+        saved_shape = (num_heads, hidden_size, num_splits) + input_shape[1:]
+        param = param.view(*saved_shape)
+        param = param.transpose(0, 2)
+        param = param.transpose(1, 2).contiguous()
+    elif checkpoint_version >= 2.0:
+        # other versions store [num_heads * num_splits * hidden_size, :]
+        saved_shape = (num_heads, num_splits, hidden_size) + input_shape[1:]
+        param = param.view(*saved_shape)
+        param = param.transpose(0, 1).contiguous()
+    param = param.view(*input_shape)
+    return param
+
+
+def get_tp_pp_degree(path_to_checkpoints):
+    TP = 1
+    PP = 1
+
+    for folder in glob(os.path.join(path_to_checkpoints, '**/*.ckpt')):
+        tp_search = re.search('[mt]p_rank_[\d]*', folder)
+        if tp_search:
+            split_key = 'tp_rank_' if 'tp_rank_' in tp_search[0] else 'mp_rank_'
+            TP = max(TP, 1+int(tp_search[0].split(split_key)[1]))
+
+        pp_search = re.search('pp_rank_[\d]*', folder)
+        if pp_search:
+            PP = max(PP, 1+int(pp_search[0].split('pp_rank_')[1]))
+            split_key = None
+
+    return TP, PP, split_key
+
+
+def _get_tp_str(tp: int):
+    tp_template = '00'
+    tp = str(tp)
+    leading_zeros = len(tp_template) - len(tp)
+    return ''.join(['0'] * leading_zeros + list(tp))
+
+
+def _get_pp_str(pp: int):
+    pp_template = '000'
+    pp = str(pp)
+    leading_zeros = len(pp_template) - len(pp)
+    return ''.join(['0'] * leading_zeros + list(pp))
+
+
+def get_step_id(path):
+    # original checkpoint (useful for sanity checking)
+    if 'model_optim_rng.ckpt' in path:
+        return 0
+
+    step_id = int(re.search('step\=(.*)\-', path)[1])
+    return int(step_id)
+
+
+def get_checkpoints_for_pp(pp: int, path_to_checkpoints: str, PP: int = 1, TP: int = 1, is_xser: bool = False, split_key=None):
+    """
+    Returns all checkpoints for specified PP rank
+    """
+    if PP == 1 and TP == 1:
+        pp_str = ""
+    else:
+        pp_str = f'tp_rank_*_pp_rank_{_get_pp_str(pp)}' if PP > 1 else f"{split_key}*"
+
+    template = join(path_to_checkpoints, pp_str, '*.ckpt')
+
+    tp_paths_sorted_by_step_id = sorted(glob(template), key=get_step_id)
+    last_step_id = get_step_id(tp_paths_sorted_by_step_id[-1])
+    print(f'Will load model for step {last_step_id}')
+    most_recent_tp_paths = [
+        p for p in tp_paths_sorted_by_step_id if get_step_id(p) == last_step_id]
+    most_recent_tp_paths_sorted_by_tp = sorted(most_recent_tp_paths)
+    print(f'paths {most_recent_tp_paths_sorted_by_tp}')
+    return {i: xser.load(p)['state_dict'] if is_xser else torch.load(p)['state_dict'] for i, p in enumerate(most_recent_tp_paths_sorted_by_tp)}
+
+
+def get_checkpoints_for_tp(tp: int, path_to_checkpoints: str, is_xser: bool = False):
+    """
+    Returns all checkpoints for specified TP rank
+    """
+    tp_str = _get_tp_str(tp)
+    template = join(path_to_checkpoints,
+                    f'tp_rank_{tp_str}_pp_rank_*', '*.ckpt')
+
+    pp_paths = sorted(glob(template))
+    return {i: xser.load(p)['state_dict'] if is_xser else torch.load(p)['state_dict'] for i, p in enumerate(pp_paths)}
+
+
+def _get_nemo_key(k, nemo_key='model.language_model.'):
+    if "final_layernorm" in k:
+        nemo_key += 'encoder.'
+    return k.replace(nemo_key, '')
+
+
+def _merge_query_and_kv(hf_model, num_layers):
+    for i in range(num_layers):
+        q_weight = hf_model[f"transformer.h.{i}.attn.c_attn_query.weight"]
+        kv_weight = hf_model[f"transformer.h.{i}.attn.c_attn_key_value.weight"]
+
+        q_bias = hf_model[f"transformer.h.{i}.attn.c_attn_query.bias"]
+        kv_bias = hf_model[f"transformer.h.{i}.attn.c_attn_key_value.bias"]
+
+        hf_model[f'transformer.h.{i}.attn.c_attn.weight'] = torch.concat(
+            [q_weight, kv_weight], dim=0)
+        hf_model[f'transformer.h.{i}.attn.c_attn.bias'] = torch.concat(
+            [q_bias, kv_bias], dim=0)
+        hf_model.pop(f"transformer.h.{i}.attn.c_attn_query.weight")
+        hf_model.pop(f"transformer.h.{i}.attn.c_attn_query.bias")
+        hf_model.pop(f"transformer.h.{i}.attn.c_attn_key_value.weight")
+        hf_model.pop(f"transformer.h.{i}.attn.c_attn_key_value.bias")
+
+    return hf_model
+
+
+def convert_checkpoint(config_file,
+                       path_to_checkpoints,
+                       output_path,
+                       checkpoint_version=2.0,
+                       is_xser=False):
+
+    with open(config_file, "r") as f:
+        config = json.load(f)
+
+    translation = {
+        "embedding.word_embeddings.weight": (1, "transformer.wte.weight", 0, 0),
+        "embedding.position_embeddings.weight": (0, "transformer.wpe.weight", None, 0),
+        "input_layernorm.weight": (0, "ln_1.weight", None, 0),
+        "input_layernorm.bias": (0, "ln_1.bias", None, 0),
+        "self_attention.query.weight": (1, "attn.c_attn_query.weight", 0, 0),
+        "self_attention.query.bias": (1, "attn.c_attn_query.bias", 0, 0),
+        "self_attention.key_value.weight": (0, "attn.c_attn_key_value.weight", None, 0),
+        "self_attention.key_value.bias": (0, "attn.c_attn_key_value.bias", None, 0),
+        "self_attention.dense.weight": (1, "attn.c_proj.weight", 1, 0),
+        "self_attention.dense.bias": (0, "attn.c_proj.bias", None, 0),
+        "post_attention_layernorm.weight": (0, "ln_2.weight", None, 0),
+        "post_attention_layernorm.bias": (0, "ln_2.bias", None, 0),
+        "mlp.dense_h_to_4h.weight": (1, "mlp.c_fc.weight", 0, 0),
+        "mlp.dense_h_to_4h.bias": (1, "mlp.c_fc.bias", 0, 0),
+        "mlp.dense_4h_to_h.weight": (1, "mlp.c_proj.weight", 1, 0),
+        "mlp.dense_4h_to_h.bias": (0, "mlp.c_proj.bias", None, 0),
+        "final_layernorm.weight": (0, "transformer.ln_f.weight", None, 0),
+        "final_layernorm.bias": (0, "transformer.ln_f.bias", None, 0),
+        "output_layer.weight": (1, "lm_head.weight", 0, 0),
+        # share_embeddings_and_output_weights
+        "model.word_embeddings.weight": (1, "lm_head.weight", 0, 0),
+    }
+
+    nemo_key = "model.language_model."
+    br_key = "transformer.h."
+
+    TP, PP, split_key = get_tp_pp_degree(path_to_checkpoints)
+
+    heads = config["n_head"]
+    hidden_size_per_head = config["n_embd"] // heads
+
+    hf_model = {}
+
+    layer_re = re.compile(
+        "model.language_model.encoder.layers\.(\d+)\.([a-z0-9_.]+)\.([a-z]+)")
+    for pp in range(PP):
+        tp_models = get_checkpoints_for_pp(
+            pp, path_to_checkpoints, PP, TP, is_xser, split_key)
+        layer_keys = tp_models[0].keys()
+        for k in layer_keys:
+            if "position_embeddings" in k:
+                nemo_key = _get_nemo_key(k)
+                _, key, _, _ = translation[nemo_key]
+                hf_model[key] = tp_models[0][k]
+                continue
+
+            if "word_embeddings" in k:
+                nemo_key = _get_nemo_key(k)
+                split, key, dim, transpose = translation[nemo_key]
+                hf_model[key] = torch.concat(
+                    [tp_models[i][k] for i in range(len(tp_models))], dim=0)
+                continue
+
+            if "output_layer" in k:
+                nemo_key = _get_nemo_key(k)
+                split, key, dim, transpose = translation[nemo_key]
+                hf_model[key] = torch.concat(
+                    [tp_models[i][k] for i in range(len(tp_models))], dim=dim)
+                continue
+
+            if "final_layernorm" in k:
+                nemo_key = _get_nemo_key(k)
+                split, key, dim, transpose = translation[nemo_key]
+                hf_model[key] = tp_models[0][k]
+                continue
+
+            m = layer_re.match(k)
+            layer_idx = m.group(1)
+            op_name = m.group(2)
+            weight_or_bias = m.group(3)
+            nemo_key = f"{op_name}.{weight_or_bias}"
+            split, key, dim, transpose = translation[nemo_key]
+            ln_idx = int(layer_idx) + pp*(config["n_layer"]//PP)
+            hf_key = f"{br_key}{ln_idx}.{key}"
+            if split:
+                hf_model[hf_key] = torch.concat(
+                    [tp_models[i][k] for i in range(len(tp_models))], dim=dim)
+            else:
+                hf_model[hf_key] = tp_models[0][k]
+            if "query" in k:
+                hf_model[hf_key] = fix_query_key_value_ordering(
+                    hf_model[hf_key], checkpoint_version, 1, heads, hidden_size_per_head)
+            elif "key_value" in k:
+                hf_model[hf_key] = fix_query_key_value_ordering(
+                    hf_model[hf_key], checkpoint_version, 2, 1, hidden_size_per_head)
+            if transpose:
+                hf_model[hf_key] = torch.transpose(hf_model[hf_key], 0, 1)
+
+    hf_model = _merge_query_and_kv(
+        hf_model=hf_model, num_layers=config["n_layer"])
+    config['vocab_size'] = hf_model['transformer.wte.weight'].shape[0]
+
+    path = Path(output_path)
+    path.mkdir(parents=True, exist_ok=True)
+    torch.save(hf_model, str(path)+"/pytorch_model.bin")
+    with open(str(path)+"/config.json", 'wt') as f:
+        json.dump(config, f)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--checkpoint_version", default=2.0)
+    parser.add_argument(
+        "--path_to_checkpoints",
+        type=str,
+        help="Path to the checkpoints from creating NeMo checkpoint files using `convert_hf_checkpoint_to_nemo.py`",
+        required=True
+    )
+    parser.add_argument(
+        "--config_file",
+        type=str,
+        help="The config json file describing the pre-trained model.",
+        required=True
+    )
+    parser.add_argument(
+        "--output_path",
+        default="",
+        type=str,
+        help="output path",
+    )
+    parser.add_argument(
+        "--is_xser",
+        default=False,
+        type=bool
+    )
+    args = parser.parse_args()
+    convert_checkpoint(args.config_file, args.path_to_checkpoints,
+                       args.output_path, args.checkpoint_version, args.is_xser)

--- a/nemo/examples/nlp/language_modeling/conf/megatron_bigcode_config.yaml
+++ b/nemo/examples/nlp/language_modeling/conf/megatron_bigcode_config.yaml
@@ -1,0 +1,223 @@
+name: megatron_bigcode
+restore_from_path: null # used when starting from a .nemo file
+
+trainer:
+  devices: 1
+  num_nodes: 1
+  accelerator: tpu
+  precision: 32
+  logger: False # logger provided by exp_manager
+  enable_checkpointing: False
+  replace_sampler_ddp: False
+  max_epochs: -1 # PTL default. In practice, max_steps will be reached first. 
+  max_steps: 100000 # consumed_samples = global_step * micro_batch_size * data_parallel_size * accumulate_grad_batches
+  log_every_n_steps: 10
+  val_check_interval: 100
+  limit_val_batches: 50
+  limit_test_batches: 500
+  accumulate_grad_batches: 1 # do not modify, grad acc is automatic for training megatron models
+  gradient_clip_val: 1.0
+  benchmark: False
+  enable_model_summary: False # default PTL callback for this does not support model parallelism, instead we log manually
+
+exp_manager:
+  create_tensorboard_logger: True
+  explicit_log_dir: null
+  exp_dir: null
+  name: megatron_bigcode
+  create_wandb_logger: False
+  wandb_logger_kwargs:
+    project: null
+    name: null
+  resume_if_exists: True
+  resume_ignore_no_checkpoint: True
+  create_checkpoint_callback: True
+  checkpoint_callback_params:
+    monitor: step
+    save_top_k: -1
+    mode: max
+    save_last: True
+    always_save_nemo: False # saves nemo file during validation, not implemented for model parallel
+    save_nemo_on_train_end: False # not recommended when training large models on clusters with short time limits
+    filename: 'megatron_bigcode--{step}-{consumed_samples}'
+    model_parallel_size: ${multiply:${model.tensor_model_parallel_size}, ${model.pipeline_model_parallel_size}}
+
+
+model:
+  # specify micro_batch_size, global_batch_size, and model parallelism
+  # gradient accumulation will be done automatically based on data_parallel_size
+  micro_batch_size: 4 # limited by GPU memory
+  global_batch_size: 8 # will use more micro batches to reach global batch size
+  tensor_model_parallel_size: 1 # intra-layer model parallelism
+  pipeline_model_parallel_size: 1 # inter-layer model parallelism
+  virtual_pipeline_model_parallel_size: null # interleaved pipeline
+
+  # model architecture
+  encoder_seq_length: 512
+  max_position_embeddings: ${.encoder_seq_length}
+  num_layers: 12
+  hidden_size: 768
+  ffn_hidden_size: 3072 # Transformer FFN hidden size. For Llama it's 8/3*hidden_size
+  num_attention_heads: 12
+  init_method_std: 0.02 # Standard deviation of the zero mean normal distribution used for weight initialization.')
+  use_scaled_init_method: True # use scaled residuals initialization
+  hidden_dropout: 0 # Dropout probability for hidden state transformer.
+  attention_dropout: 0 # Dropout probability in the attention layer.
+  ffn_dropout: 0 # Dropout probability in the feed-forward layer.
+  kv_channels: null # Projection weights dimension in multi-head attention. Set to hidden_size // num_attention_heads if null
+  apply_query_key_layer_scaling: True # scale Q * K^T by 1 / layer-number.
+  normalization: 'layernorm' # Type of normalization layers ['rmsnorm', 'layernorm']
+  layernorm_epsilon: 1e-5
+  do_layer_norm_weight_decay: False # True means weight decay on all params
+  make_vocab_size_divisible_by: 8 # Pad the vocab size to be divisible by this value for computation efficiency.
+  pre_process: True # add embedding
+  post_process: True # add pooler
+  persist_layer_norm: True # Use of persistent fused layer norm kernel.
+  share_embeddings_and_output_weights: False # Untie embedding and output layer weights.
+  activation: 'gelu' # ['swiglu', 'gelu']
+  transformer_block_type: 'pre_ln' # ['pre_ln', 'post_ln', 'normformer', 'gpt_j'] https://github.com/EleutherAI/gpt-neox/blob/303d7be582ae1c969347c25c54f568cc122445fc/megatron/model/transformer.py#L804-L847
+  has_bias: True
+  #num_query_groups: ${.num_attention_heads}
+
+  tokenizer:
+    library: 'huggingface'
+    type: null
+    model: null
+    vocab_file: null
+    merge_file: null 
+    delimiter: null # only used for tabular tokenizer
+    sentencepiece_legacy: False # Legacy=True allows you to add special tokens to sentencepiece tokenizers.
+    use_fast: False
+
+  # Mixed precision
+  native_amp_init_scale: 4294967296 # 2 ** 32
+  native_amp_growth_interval: 1000
+  hysteresis: 2 # Gradient scale hysteresis
+  fp32_residual_connection: False # Move residual connections to fp32
+  fp16_lm_cross_entropy: False # Move the cross entropy unreduced loss calculation for lm head to fp16
+
+  # Megatron O2-style half-precision
+  megatron_amp_O2: False # Enable O2-level automatic mixed precision using main parameters
+  grad_allreduce_chunk_size_mb: 125
+
+  # Fusion
+  grad_div_ar_fusion: False # Fuse grad division into torch.distributed.all_reduce. Only used with O2 and no pipeline parallelism..
+  gradient_accumulation_fusion: False # Fuse weight gradient accumulation to GEMMs. Only used with pipeline parallelism and O2.
+  bias_activation_fusion: False # Use a kernel that fuses the bias addition from weight matrices with the subsequent activation function.
+  bias_dropout_add_fusion: False # Use a kernel that fuses the bias addition, dropout and residual connection addition.
+  masked_softmax_fusion: False # Use a kernel that fuses the attention softmax with it's mask.
+
+
+  # Miscellaneous
+  seed: 1234
+  resume_from_checkpoint: null # manually set the checkpoint file to load from
+  use_cpu_initialization: False # Init weights on the CPU (slow for large models)
+  onnx_safe: False # Use work-arounds for known problems with Torch ONNX exporter.
+  apex_transformer_log_level: 30 # Python logging level displays logs with severity greater than or equal to this
+  gradient_as_bucket_view: True # PyTorch DDP argument. Allocate gradients in a contiguous bucket to save memory (less fragmentation and buffer memory)
+  sync_batch_comm: False # Enable stream synchronization after each p2p communication between pipeline stages
+  log_parameter_norm: False # Logs parameter norm across model parallel ranks
+  log_gradient_norm: False # Logs gradient norm across model parallel ranks
+  save_logits: False # Saves logits in numpy array of dimensions batch x sequence_length x vocab_size
+  save_logits_interval: 0 # Step interval at which to save logits to disk - Note should be Zero Indexed
+
+
+  ## Activation Checkpointing
+  # NeMo Megatron supports 'selective' activation checkpointing where only the memory intensive part of attention is checkpointed.
+  # These memory intensive activations are also less compute intensive which makes activation checkpointing more efficient for LLMs (20B+).
+  # See Reducing Activation Recomputation in Large Transformer Models: https://arxiv.org/abs/2205.05198 for more details.
+  # 'full' will checkpoint the entire transformer layer.
+  activations_checkpoint_granularity: selective # 'selective' or 'full' 
+  activations_checkpoint_method: uniform # 'uniform', 'block'
+  # 'uniform' divides the total number of transformer layers and checkpoints the input activation
+  # of each chunk at the specified granularity. When used with 'selective', 'uniform' checkpoints all attention blocks in the model.
+  # 'block' checkpoints the specified number of layers per pipeline stage at the specified granularity
+  activations_checkpoint_num_layers: 1
+  # when using 'uniform' this creates groups of transformer layers to checkpoint. Usually set to 1. Increase to save more memory.
+  # when using 'block' this this will checkpoint the first activations_checkpoint_num_layers per pipeline stage.
+  num_micro_batches_with_partial_activation_checkpoints: null
+  # This feature is valid only when used with pipeline-model-parallelism.
+  # When an integer value is provided, it sets the number of micro-batches where only a partial number of Transformer layers get checkpointed
+  # and recomputed within a window of micro-batches. The rest of micro-batches in the window checkpoint all Transformer layers. The size of window is
+  # set by the maximum outstanding micro-batch backpropagations, which varies at different pipeline stages. The number of partial layers to checkpoint
+  # per micro-batch is set by 'activations_checkpoint_num_layers' with 'activations_checkpoint_method' of 'block'.
+  # This feature enables using activation checkpoint at a fraction of micro-batches up to the point of full GPU memory usage.
+  activations_checkpoint_layers_per_pipeline: null
+  # This feature is valid only when used with pipeline-model-parallelism.
+  # When an integer value (rounded down when float is given) is provided, it sets the number of Transformer layers to skip checkpointing at later
+  # pipeline stages. For example, 'activations_checkpoint_layers_per_pipeline' of 3 makes pipeline stage 1 to checkpoint 3 layers less than
+  # stage 0 and stage 2 to checkpoint 6 layers less stage 0, and so on. This is possible because later pipeline stage
+  # uses less GPU memory with fewer outstanding micro-batch backpropagations. Used with 'num_micro_batches_with_partial_activation_checkpoints',
+  # this feature removes most of activation checkpoints at the last pipeline stage, which is the critical execution path.
+
+  ## Sequence Parallelism
+  # Makes tensor parallelism more memory efficient for LLMs (20B+) by parallelizing layer norms and dropout sequentially
+  # See Reducing Activation Recomputation in Large Transformer Models: https://arxiv.org/abs/2205.05198 for more details.
+  sequence_parallel: True
+
+  ## Zero Redundancy Optimizer
+  # Wraps your chosen optimizer with a Zero Redundancy Optimizer
+  # Partitions optimizer states across ranks reducing memory consumption
+  wrap_with_zero: False
+
+  ## Transformer Engine
+  transformer_engine: False
+  fp8: False # enables fp8 in TransformerLayer forward
+  fp8_e4m3: False # sets fp8_format = recipe.Format.E4M3 
+  fp8_hybrid: False # sets fp8_format = recipe.Format.HYBRID
+  fp8_margin: 0 # scaling margin 
+  fp8_interval: 1 # scaling update interval
+  fp8_amax_history_len: 1 # Number of steps for which amax history is recorded per tensor
+  fp8_amax_compute_algo: most_recent # 'most_recent' or 'max'. Algorithm for computing amax from history
+  use_emha: False # Use fused multi-head attention for large sequence-length. Note this is not yet supported. Please set to False.
+
+  data:
+   # Path to data must be specified by the user.
+    # Supports List, String and Dictionary
+    # List : can override from the CLI: "model.data.data_prefix=[.5,/raid/data/pile/my-gpt3_00_text_document,.5,/raid/data/pile/my-gpt3_01_text_document]",
+    # Or see example below: 
+    # data_prefix: 
+    #   - .5
+    #   - /raid/data/pile/my-gpt3_00_text_document
+    #   - .5
+    #   - /raid/data/pile/my-gpt3_01_text_document
+    # Dictionary: can override from CLI "model.data.data_prefix"={"train":[1.0, /path/to/data], "validation":/path/to/data, "test":/path/to/test}
+    # Or see example below:
+    # "model.data.data_prefix: {train:[1.0,/path/to/data], validation:[/path/to/data], test:[/path/to/test]}"
+    data_prefix: ???
+    index_mapping_dir: null # path to save index mapping .npy files, by default will save in the same location as data_prefix
+    data_impl: mmap
+    splits_string: 980,10,10
+    seq_length: ${model.encoder_seq_length}
+    skip_warmup: True
+    num_workers: 2
+    dataloader_type: single # cyclic
+    reset_position_ids: False # Reset position ids after end-of-document token
+    reset_attention_mask: False # Reset attention mask after end-of-document token
+    eod_mask_loss: False # Mask loss for the end of document tokens
+    validation_drop_last: True # Set to false if the last partial validation samples is to be consumed
+    no_seqlen_plus_one_input_tokens: False # Set to True to disable fetching (sequence length + 1) input tokens, instead get (sequence length) input tokens and mask the last token
+    pad_samples_to_global_batch_size: False # Set to True if you want to pad the last partial batch with -1's to equal global batch size
+    fim_rate: 0.5
+    fim_spm_rate: 0
+  # Nsys profiling options
+  nsys_profile:
+    enabled: False
+    start_step: 10  # Global batch to start profiling
+    end_step: 10 # Global batch to end profiling
+    ranks: [0] # Global rank IDs to profile
+    gen_shape: False # Generate model and kernel details including input shapes
+  
+  optim:
+    name: adamw
+    lr: 2e-4
+    weight_decay: 0.01 
+    capturable: False
+    betas: 
+    - 0.9
+    - 0.98
+    sched:
+      name: CosineAnnealing
+      warmup_steps: 500
+      constant_steps: 50000
+      min_lr: 2e-5

--- a/nemo/examples/nlp/language_modeling/megatron_bigcode_pretraining.py
+++ b/nemo/examples/nlp/language_modeling/megatron_bigcode_pretraining.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import lightning_neuron_patch
+import os
+
+from lightning_lite.plugins.environments import TorchElasticEnvironment
+from omegaconf.omegaconf import OmegaConf, open_dict
+from pytorch_lightning import Trainer
+from omegaconf.dictconfig import DictConfig
+from pytorch_lightning.callbacks.timer import Timer
+from pytorch_lightning.trainer.connectors.checkpoint_connector import CheckpointConnector
+from nemo.collections.nlp.models.language_modeling.megatron_bigcode_model import MegatronBigCodeModel
+
+from nemo.collections.nlp.parts.nlp_overrides import (
+    GradScaler,
+    MegatronHalfPrecisionPlugin,
+    NLPDDPStrategy,
+    PipelineMixedPrecisionPlugin,
+    NLPTrainer,
+    NLPCheckpointIO,
+    NLPSaveRestoreConnector
+)
+from nemo.core.config import hydra_runner
+from nemo.utils import logging
+from nemo.utils.exp_manager import StatelessTimer, exp_manager
+
+import torch.optim.adamw as torch_adamw
+from nemo.core.optim.adamw import _single_tensor_adamw_
+torch_adamw._single_tensor_adamw = _single_tensor_adamw_
+
+
+@hydra_runner(config_path="conf", config_name="megatron_llama_70b_config")
+def main(cfg) -> None:
+    logging.info("\n\n************** Experiment configuration ***********")
+    logging.info(f'\n{OmegaConf.to_yaml(cfg)}')
+
+    megatron_amp_o2 = cfg.model.get('megatron_amp_O2', False)
+    with_distributed_adam = cfg.model.optim.get(
+        'name') == 'distributed_fused_adam'
+    plugins = []
+
+    nlp_xla_checkpoint_io = NLPCheckpointIO()
+    cluster_environment = None
+    if os.environ.get("TORCHELASTIC_RUN_ID") is not None:
+        cluster_environment = TorchElasticEnvironment()
+    strategy = NLPDDPStrategy(
+        no_ddp_communication_hook=True,  # we don't use DDP for async grad allreduce
+        gradient_as_bucket_view=cfg.model.gradient_as_bucket_view,
+        find_unused_parameters=False,
+        cluster_environment=cluster_environment,
+        checkpoint_io=nlp_xla_checkpoint_io,
+        megatron_amp_o2=megatron_amp_o2,
+        restore_path=cfg.model.resume_from_checkpoint
+    )
+    if cfg.trainer.precision in [16, 'bf16']:
+        scaler = None
+        if cfg.trainer.precision == 16:
+            scaler = GradScaler(
+                init_scale=cfg.model.get('native_amp_init_scale', 2 ** 32),
+                growth_interval=cfg.model.get(
+                    'native_amp_growth_interval', 1000),
+                hysteresis=cfg.model.get('hysteresis', 2),
+            )
+        if megatron_amp_o2 and not with_distributed_adam:
+            plugins.append(MegatronHalfPrecisionPlugin(
+                precision=cfg.trainer.precision, device='cuda', scaler=scaler))
+        else:
+            plugins.append(PipelineMixedPrecisionPlugin(
+                precision=cfg.trainer.precision, device='cuda', scaler=scaler))
+
+    if cfg.get('cluster_type', None) == 'BCP':
+        plugins.append(TorchElasticEnvironment())
+
+    # update resume from checkpoint found by exp_manager
+    if cfg.model.resume_from_checkpoint is not None:
+        resume_from_checkpoint = cfg.model.resume_from_checkpoint
+        trainer = NLPTrainer(plugins=plugins, strategy=strategy,
+                             resume_from_checkpoint=resume_from_checkpoint, **cfg.trainer)
+    else:
+        trainer = NLPTrainer(plugins=plugins, strategy=strategy, **cfg.trainer)
+
+    exp_manager(trainer, cfg.exp_manager)
+    # We use NLPCheckpointConnector which correctly loads global_step, epoch
+    # trainer._checkpoint_connector = CheckpointConnector(trainer, resume_from_checkpoint=resume_from_checkpoint)
+    # Override timer callback to a stateless one
+    for idx, callback in enumerate(trainer.callbacks):
+        if isinstance(callback, Timer):
+            trainer.callbacks[idx] = StatelessTimer(cfg.trainer.max_time,)
+
+    # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
+    with open_dict(cfg):
+        cfg.model.precision = cfg.trainer.precision
+
+    model = MegatronBigCodeModel(cfg.model, trainer)
+    trainer.fit(model)
+
+
+if __name__ == '__main__':
+    main()

--- a/nemo/examples/nlp/language_modeling/starcoder_15b.sh
+++ b/nemo/examples/nlp/language_modeling/starcoder_15b.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# model architecture
+export SEQ_LENGTH=8192
+export HS=6144
+export N_LAYERS=40
+export N_AH=48
+export FFN_HS=24576
+export TP=8
+export PP=4
+
+# hyperparameters
+export FIM_RATE=0.5
+export FIM_SPM_RATE=0
+export TRAIN_ITERS=2000
+export GBS=$((256*SLURM_NTASKS))
+
+./test_bigcode.sh

--- a/nemo/examples/nlp/language_modeling/starcoder_7b.sh
+++ b/nemo/examples/nlp/language_modeling/starcoder_7b.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# model architecture
+export SEQ_LENGTH=8192
+export HS=4096
+export N_LAYERS=42
+export N_AH=32
+export FFN_HS=16384
+export TP=8
+export PP=2
+
+# hyperparameters
+export FIM_RATE=0.5
+export FIM_SPM_RATE=0
+export TRAIN_ITERS=2000
+export GBS=$((256*SLURM_NTASKS))
+
+./test_bigcode.sh

--- a/nemo/examples/nlp/language_modeling/test_bigcode.sh
+++ b/nemo/examples/nlp/language_modeling/test_bigcode.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+source ./train_setup.sh
+
+: ${TRAIN_ITERS:=20000}
+: ${INIT_METHOD_STD:=0.021}
+: ${LAYERNORM_EPSILON:=1e-5}
+: ${WARMUP_STEPS:=10}
+
+: ${SEQ_LENGTH:=8192}
+: ${HS:=4096}
+: ${TP:=8}
+: ${PP:=2}
+: ${N_LAYERS:=42}
+: ${N_AH:=32}
+: ${UBS:=1}
+: ${FFN_HS:=16384}
+: ${GBS:=256}
+: ${FIM_RATE:=0.5}
+: ${FIM_SPM_RATE:=0}
+: ${TOKENIZER_PATH=$HOME/examples_datasets/starcoder/starcoder_model}
+: ${DATASET_PATH=$HOME/examples_datasets/starcoder/codeparrot-clean-mmap_content_document}
+
+echo "SEQ_LEN=$SEQ_LENGTH, HS=$HS, FFN_HS=$FFN_HS TP=$TP PP=$PP N_LAYERS=$N_LAYERS N_AH=$N_AH GBS=$GBS UBS=$UBS TRAIN_ITERS=$TRAIN_ITERS"
+
+LOG_PATH=logs/$SLURM_JOB_ID/$NODEID/
+mkdir -p $LOG_PATH
+
+$MAYBE_COMPILE torchrun $DISTRIBUTED_ARGS megatron_bigcode_pretraining.py  \
+    --config-path=conf \
+    --config-name=megatron_bigcode_config \
+    trainer.devices=$PROCESSES_PER_NODE \
+    trainer.num_nodes=$NTASKS \
+    trainer.max_epochs=null \
+    trainer.max_steps=$TRAIN_ITERS\
+    trainer.val_check_interval=$TRAIN_ITERS \
+    trainer.log_every_n_steps=1 \
+    trainer.limit_val_batches=1 \
+    trainer.limit_test_batches=1 \
+    trainer.accumulate_grad_batches=1 \
+    trainer.precision=32 \
+    model.megatron_amp_O2=$megatron_amp_O2 \
+    model.tokenizer.type=$TOKENIZER_PATH \
+    model.micro_batch_size=$UBS \
+    model.global_batch_size=$GBS \
+    model.tensor_model_parallel_size=$TP \
+    model.pipeline_model_parallel_size=$PP \
+    model.max_position_embeddings=$SEQ_LENGTH \
+    model.encoder_seq_length=$SEQ_LENGTH \
+    model.hidden_size=$HS \
+    model.ffn_hidden_size=$FFN_HS \
+    model.num_layers=$N_LAYERS \
+    model.num_attention_heads=$N_AH \
+    model.init_method_std=$INIT_METHOD_STD \
+    model.hidden_dropout=0 \
+    model.layernorm_epsilon=$LAYERNORM_EPSILON \
+    model.data.data_prefix=[1.0,$DATASET_PATH] \
+    model.data.num_workers=1 \
+    model.data.seq_length=$SEQ_LENGTH \
+    model.optim.name=$OPTIM_NAME \
+    model.optim.lr=3.0e-4 \
+    model.optim.betas=[0.9,0.95] \
+    model.optim.weight_decay=0.1 \
+    model.optim.sched.name=CosineAnnealing \
+    model.optim.sched.warmup_steps=$WARMUP_STEPS \
+    model.optim.sched.constant_steps=0 \
+    model.optim.sched.min_lr=3.0e-5 \
+    model.optim.capturable=True \
+    model.sequence_parallel=True  \
+    model.activations_checkpoint_granularity=full \
+    model.activations_checkpoint_method=uniform \
+    model.activations_checkpoint_num_layers=1 \
+    +model.save_xser=True\
+    model.data.fim_rate=$FIM_RATE \
+    model.data.fim_spm_rate=$FIM_SPM_RATE \
+    exp_manager.create_tensorboard_logger=$CREATE_TB_LOGGER \
+    exp_manager.resume_if_exists=False \
+    exp_manager.resume_ignore_no_checkpoint=False \
+    exp_manager.create_checkpoint_callback=$CHECKPOINT_CALLBACK \
+    +exp_manager.checkpoint_callback_params.train_time_interval=36000 \
+    model.use_cpu_initialization=True   2>&1  | tee  $LOG_PATH/log
+
+# Note: to resume training using a checkpoint, please add the following configuration above, adjusting for your checkpoint path
+#    model.use_cpu_initialization=False \
+#    +model.load_xser=True \
+#    model.resume_from_checkpoint='/efs/checkpoint/megatron_gpt--step\=1085-consumed_samples\=69632.0-last.ckpt' \

--- a/nemo/nemo/collections/common/tokenizers/tokenizer_spec.py
+++ b/nemo/nemo/collections/common/tokenizers/tokenizer_spec.py
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+FIM_PREFIX = "<fim_prefix>"
+FIM_MIDDLE = "<fim_middle>"
+FIM_SUFFIX = "<fim_suffix>"
+FIM_PAD = "<fim_pad>"
+EOD = "<|endoftext|>"
+
 from abc import ABC, abstractmethod
 from typing import List
 

--- a/nemo/nemo/collections/nlp/data/language_modeling/megatron/gpt_dataset.py
+++ b/nemo/nemo/collections/nlp/data/language_modeling/megatron/gpt_dataset.py
@@ -33,6 +33,7 @@ from nemo.collections.nlp.data.language_modeling.megatron.indexed_dataset import
 from nemo.core import Dataset
 from nemo.utils import logging
 from transformers.utils import is_torch_tpu_available
+from nemo.collections.common.tokenizers.tokenizer_spec import FIM_PREFIX, FIM_MIDDLE, FIM_SUFFIX, FIM_PAD, EOD
 
 try:
     from apex.transformer import parallel_state
@@ -321,10 +322,12 @@ class GPTDataset(Dataset):
             )
 
         super().__init__()
+        self.tokenizer = tokenizer
         self.name = name
         self.indexed_dataset = indexed_dataset
         self.drop_last = drop_last
         self.seq_length = seq_length
+        self.np_rng = np.random.RandomState(seed=seed) # rng state for FIM
 
         # Checks
         assert np.min(documents) >= 0
@@ -332,10 +335,15 @@ class GPTDataset(Dataset):
 
         self.reset_position_ids = cfg.data.get('reset_position_ids', False)
         self.reset_attention_mask = cfg.data.get('reset_attention_mask', False)
+        self.fim_rate = cfg.data.get('fim_rate', 0)
+        self.fim_spm_rate = cfg.data.get('fim_spm_rate', 0)
         self.eod_mask_loss = cfg.data.get('eod_mask_loss', False)
         self.eos_id = tokenizer.eos_id
+        self.eod_id = tokenizer.eos_id # as defined in https://github.com/bigcode-project/Megatron-LM/blob/bd0aaba3492b441d7f186bb1159fc21e1dcd7a72/megatron/tokenizer/tokenizer.py#L288
         self.no_seqlen_plus_one_input_tokens = cfg.data.get('no_seqlen_plus_one_input_tokens', False)
         self.add_extra_token = 1
+        self.suffix_tok_id, self.prefix_tok_id, self.middle_tok_id, self.pad_tok_id = (self.tokenizer.token_to_id(tok) for tok in [FIM_SUFFIX, FIM_PREFIX, FIM_MIDDLE, FIM_PAD])
+
         if self.no_seqlen_plus_one_input_tokens:
             self.add_extra_token = 0
 
@@ -394,7 +402,54 @@ class GPTDataset(Dataset):
                 self.indexed_dataset.get(self.doc_idx[doc_index_l], length=offset_l + self.add_extra_token)
             )
             sample = np.concatenate(sample_list)
-        if len(sample) != (self.seq_length + self.add_extra_token):
+        ###
+        # Code from: https://github.com/EleutherAI/gpt-neox/blob/FIM-clean/megatron/data/gpt2_dataset.py#L109
+        # TODO(Hailey): can merge the code below this line with code above this line.
+        # TODO(Hailey), cont: above already iterates through loop, so just add the permuting in there?
+        sample = np.array(sample, dtype=np.int64)
+        sample_len = sample.shape[0]
+        # # print(sample, sample.shape)
+        # # do FIM here, if enabled
+        # TODO: Do we handle the following point from FIM paper?
+        # To transform data in the character space for context-level FIM, the tokenized documents have to be decoded back into strings before FIM augmentation. Depending on the vocabulary, some care has to be given to ensure decoding does not introduce any spurious characters into training. For example, utf-8 characters are encoded as multiple tokens with a BPE vocabulary; they can result in fragments from chunking and fail to decode. To prevent unforeseen errors midway through training, we encourage checking for these fragments at the beginning or end of a context and removing them.
+        fim_rate = self.fim_rate
+
+        if fim_rate != 0:
+            assert (fim_rate <= 1 and fim_rate >= 0), "FIM rate must be a probability 0 <= rate <= 1"
+
+            eod = self.eod_id
+            segment_breaks = np.argwhere(sample == eod) # split sample by document
+
+            if segment_breaks.shape != (0, 1): # then there is an EOD token in this example
+                curr_start_position = 0
+                new_samples = []
+                for loc in np.nditer(segment_breaks):
+                    # Only permute non-empty segments.
+                    if loc - curr_start_position > 0:
+                        # permute {prefix, suffix, middle} or {suffix, prefix, middle}
+                        permuted, self.np_rng = \
+                            permute(sample[curr_start_position:loc], self.np_rng, self.fim_rate, self.fim_spm_rate, self.tokenizer, truncate_or_pad=False,
+                                    suffix_tok_id=self.suffix_tok_id, prefix_tok_id=self.prefix_tok_id, middle_tok_id=self.middle_tok_id, pad_tok_id=self.pad_tok_id)
+                        new_samples += [permuted, [eod]]
+
+                    curr_start_position = loc + 1 # jump over the EOD token
+                # Permute the segment after the last EOD
+                permuted, self.np_rng = \
+                    permute(sample[curr_start_position:], self.np_rng, self.fim_rate, self.fim_spm_rate, self.tokenizer, truncate_or_pad=False,
+                            suffix_tok_id=self.suffix_tok_id, prefix_tok_id=self.prefix_tok_id, middle_tok_id=self.middle_tok_id, pad_tok_id=self.pad_tok_id)
+                new_samples.append(permuted)
+
+                sample = np.concatenate(new_samples)
+            else:
+                sample, self.np_rng = permute(sample, self.np_rng, self.fim_rate, self.fim_spm_rate, self.tokenizer, truncate_or_pad=False,
+                                              suffix_tok_id=self.suffix_tok_id, prefix_tok_id=self.prefix_tok_id, middle_tok_id=self.middle_tok_id, pad_tok_id=self.pad_tok_id)
+
+        # Truncate or pad sequence to max-length
+        diff = sample.shape[0] - (self.seq_length + self.add_extra_token)
+        if diff > 0: # too long
+            sample = sample[:(self.seq_length + self.add_extra_token)]
+        elif diff < 0: # too short
+        #    sample = np.concatenate([sample, np.full((-1 * diff), self.pad_tok_id)])
             logging.info(
                 F' > WARNING: Got sample of length: {len(sample)} for sequence length={self.seq_length+self.add_extra_token}, padding the sample to match sequence length'
             )
@@ -402,6 +457,18 @@ class GPTDataset(Dataset):
             sample = np.pad(
                 sample, (0, self.seq_length + self.add_extra_token - len(sample)), mode='constant', constant_values=-1
             )
+
+        assert sample.shape[0] == (self.seq_length + self.add_extra_token)
+        # end FIM-specific code
+        ###
+        #if len(sample) != (self.seq_length + self.add_extra_token):
+        #    logging.info(
+        #        F' > WARNING: Got sample of length: {len(sample)} for sequence length={self.seq_length+self.add_extra_token}, padding the sample to match sequence length'
+        #    )
+        #    sample = np.array(sample, dtype=np.int64)
+        #    sample = np.pad(
+        #        sample, (0, self.seq_length + self.add_extra_token - len(sample)), mode='constant', constant_values=-1
+        #    )
         return sample.astype(np.int64)
 
     def __getitem__(self, idx):
@@ -770,3 +837,68 @@ def _build_shuffle_idx(num_samples, total_size, np_rng):
     np_rng.shuffle(shuffle_idx_last)
 
     return np.concatenate((shuffle_idx_first, shuffle_idx_last))
+
+# From https://github.com/EleutherAI/gpt-neox/blob/FIM-clean/megatron/data/gpt2_dataset.py#L339
+def permute(sample, np_rng, fim_rate, fim_spm_rate, tokenizer, truncate_or_pad=True,
+            suffix_tok_id=None, prefix_tok_id=None, middle_tok_id=None, pad_tok_id=None):
+    """
+    Take in a sample (np array w/ size (0,chunklength)) and perform a FIM transformation on it.
+    Maintain the same sample length (if transform creates a few extra tokens, drop them).
+    """
+
+    if np_rng.binomial(1, fim_rate): # sample bernoulli dist
+
+        contents = tokenizer.ids_to_text(sample)
+
+        try:
+            # A boundary can be =0 (prefix will be empty)
+            # a boundary can be =len(contents) (suffix will be empty)
+            # The two boundaries can be equal (middle will be empty)
+            boundaries = list(np_rng.randint(low=0, high=len(contents) + 1, size=2))
+            boundaries.sort()
+        except ValueError as e:
+            print(len(contents), contents)
+            print(e)
+            raise e
+
+        prefix = contents[:boundaries[0]]
+        middle = contents[boundaries[0]:boundaries[1]]
+        suffix = contents[boundaries[1]:]
+
+        prefix = np.array([*tokenizer.text_to_ids(prefix)], dtype=np.int64)
+        middle = np.array([*tokenizer.text_to_ids(middle)], dtype=np.int64)
+        suffix = np.array([*tokenizer.text_to_ids(suffix)], dtype=np.int64)
+
+        # here we truncate each given segment to fit the same length as it was before
+        # A consequence is that we never reach the end of a file?
+        # we should rather truncate at the context-level
+        if truncate_or_pad:
+            # need to make same length as the input. Take the 3 sentinel tokens into account
+            new_length = suffix.shape[0] + prefix.shape[0] + middle.shape[0] + 3
+            diff = new_length - sample.shape[0]
+            if diff > 0: # too long
+                if suffix.shape[0] <= diff: # if there's no space to truncate the suffix: stop and report it. atm i should have stopped this from happening
+                    return sample, np_rng
+                suffix = suffix[:suffix.shape[0] - diff]
+            elif diff < 0: # too short
+                suffix = np.concatenate([suffix, np.full((-1 * diff), pad_tok_id)])
+
+        if np_rng.binomial(1, fim_spm_rate):
+            # SPM (variant 2 from FIM paper)
+            new_sample = np.concatenate([
+                [prefix_tok_id, suffix_tok_id], suffix,
+                [middle_tok_id], prefix, middle
+            ])
+        else:
+            # PSM
+            new_sample = np.concatenate([
+                [prefix_tok_id], prefix,
+                [suffix_tok_id], suffix,
+                [middle_tok_id], middle
+            ])
+
+    else:
+        # don't do FIM preproc
+        new_sample = sample
+
+    return new_sample, np_rng

--- a/nemo/nemo/collections/nlp/models/language_modeling/megatron/bigcode_model.py
+++ b/nemo/nemo/collections/nlp/models/language_modeling/megatron/bigcode_model.py
@@ -1,0 +1,347 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPT-2 model."""
+
+import torch
+from nemo.utils import logging
+from nemo.collections.nlp.modules.common.megatron.bigcode_module import get_bigcode_language_model
+from nemo.collections.nlp.modules.common.megatron.module import MegatronModule
+from nemo.collections.nlp.modules.common.megatron.utils import (
+    ApexGuardDefaults,
+    init_method_normal,
+    parallel_lm_logits,
+    scaled_init_method_normal,
+)
+
+try:
+    from apex.transformer import tensor_parallel, parallel_state
+    from apex.transformer.enums import AttnMaskType
+
+    HAVE_APEX = True
+except (ImportError, ModuleNotFoundError):
+    HAVE_APEX = False
+    # fake missing classes with None attributes
+    AttnMaskType = ApexGuardDefaults()
+
+
+def post_language_model_processing(
+    lm_output,
+    labels,
+    logit_weights,
+    get_key_value,
+    parallel_output,
+    forward_method_parallel_output,
+    fp16_lm_cross_entropy,
+    return_logits=False,
+    sequence_parallel=False,
+    gradient_accumulation_fusion=False,
+    share_embeddings_and_output_weights=True,
+):
+    if share_embeddings_and_output_weights == False:
+        lm_output = lm_output.transpose(0, 1).contiguous()
+        # Output.
+        if labels is None:
+            return lm_output
+        else:
+            logits = None
+            if return_logits:
+                logits = output.clone()
+            if fp16_lm_cross_entropy:
+                assert lm_output.dtype == torch.half
+                loss = tensor_parallel.vocab_parallel_cross_entropy(
+                    lm_output, labels)
+            else:
+                loss = tensor_parallel.vocab_parallel_cross_entropy(
+                    lm_output.float(), labels)
+
+            return loss, logits
+    if get_key_value:
+        lm_output, presents = lm_output
+
+    # Output. Format is [s b h]
+    if forward_method_parallel_output is not None:
+        parallel_output = forward_method_parallel_output
+    async_tensor_model_parallel_allreduce = (
+        parallel_state.get_tensor_model_parallel_world_size() > 1 and not sequence_parallel
+    )
+    output = parallel_lm_logits(
+        lm_output,
+        logit_weights,
+        parallel_output,
+        sequence_parallel=sequence_parallel,
+        gradient_accumulation_fusion=gradient_accumulation_fusion,
+        async_tensor_model_parallel_allreduce=async_tensor_model_parallel_allreduce,
+    )
+    logits = None
+    if return_logits:
+        # Logits are [batch x seq_length x vocab_size]
+        logits = output.clone()
+
+    if get_key_value:
+        output = [output, presents]
+
+    if labels is None:
+        # [s b h] -> [b s h]
+        return output.transpose(0, 1).contiguous()
+    else:
+        # [b s] -> [s b]
+        labels = labels.transpose(0, 1).contiguous()
+
+        if fp16_lm_cross_entropy:
+            assert output.dtype == torch.half
+            loss = tensor_parallel.vocab_parallel_cross_entropy(output, labels)
+        else:
+            loss = tensor_parallel.vocab_parallel_cross_entropy(
+                output.float(), labels)
+
+        # [s b] -> [b, s]
+        loss = loss.transpose(0, 1).contiguous()
+        return loss, logits
+
+
+class BigCodeModel(MegatronModule):
+    """BigCode Language model."""
+
+    def __init__(
+        self,
+        vocab_size,
+        hidden_size,
+        max_position_embeddings,
+        num_layers,
+        num_attention_heads,
+        ffn_hidden_size,
+        apply_query_key_layer_scaling=True,
+        kv_channels=None,
+        num_tokentypes=0,
+        parallel_output=True,
+        pre_process=True,
+        post_process=True,
+        init_method_std=0.02,
+        use_scaled_init_method=True,
+        fp16_lm_cross_entropy=False,
+        use_cpu_initialization=False,
+        hidden_dropout=0.1,
+        attention_dropout=0.1,
+        ffn_dropout=0.0,
+        precision=16,
+        fp32_residual_connection=False,
+        activations_checkpoint_granularity=None,
+        activations_checkpoint_method=None,
+        activations_checkpoint_num_layers=1,
+        activations_checkpoint_layers_per_pipeline=None,
+        normalization='layernorm',
+        layernorm_epsilon=1e-5,
+        bias=True,
+        bias_activation_fusion=True,
+        bias_dropout_add_fusion=True,
+        masked_softmax_fusion=True,
+        activation='gelu',
+        headscale=False,
+        transformer_block_type='pre_ln',
+        normalize_attention_scores=True,
+        position_embedding_type='learned_absolute',
+        rotary_percentage=1.0,
+        attention_type='multihead',
+        share_embeddings_and_output_weights=True,
+        gradient_accumulation_fusion=False,
+        persist_layer_norm=False,
+        openai_gelu=False,
+        onnx_safe=False,
+        sequence_parallel=False,
+        transformer_engine=False,
+        fp8=False,
+        fp8_e4m3=False,
+        fp8_hybrid=False,
+        fp8_margin=0,
+        fp8_interval=1,
+        fp8_amax_history_len=1,
+        fp8_amax_compute_algo='most_recent',
+        reduce_amax=True,
+        use_emha=False,
+        save_logits=False,
+        position_interpolation_factor=1.0,
+    ):
+
+        super(BigCodeModel, self).__init__(
+            share_token_embeddings=share_embeddings_and_output_weights)
+
+        self.parallel_output = parallel_output
+        self.pre_process = pre_process
+        self.post_process = post_process
+        self.fp16_lm_cross_entropy = fp16_lm_cross_entropy
+        self.sequence_parallel = sequence_parallel
+        self.gradient_accumulation_fusion = gradient_accumulation_fusion
+        self.share_embeddings_and_output_weights = share_embeddings_and_output_weights
+        self.save_logits = save_logits
+
+        if kv_channels is None:
+            assert (
+                hidden_size % num_attention_heads == 0
+            ), 'hidden_size must be divisible by num_attention_heads if kv_channels is None'
+            kv_channels = hidden_size // num_attention_heads
+
+        scaled_init_method = (
+            scaled_init_method_normal(init_method_std, num_layers)
+            if use_scaled_init_method
+            else init_method_normal(init_method_std)
+        )
+
+        logging.trace(
+            f"In GPTModel._init_() enter get_language_model()", trace_type="recovery_time")
+
+        self.language_model, self._language_model_key = get_bigcode_language_model(
+            vocab_size=vocab_size,
+            hidden_size=hidden_size,
+            hidden_dropout=hidden_dropout,
+            attention_dropout=attention_dropout,
+            ffn_dropout=ffn_dropout,
+            num_tokentypes=num_tokentypes,
+            max_position_embeddings=max_position_embeddings,
+            num_layers=num_layers,
+            num_attention_heads=num_attention_heads,
+            apply_query_key_layer_scaling=apply_query_key_layer_scaling,
+            kv_channels=kv_channels,
+            ffn_hidden_size=ffn_hidden_size,
+            add_pooler=False,
+            encoder_attn_mask_type=AttnMaskType.causal,
+            init_method=init_method_normal(init_method_std),
+            scaled_init_method=scaled_init_method,
+            add_decoder=False,
+            pre_process=self.pre_process,
+            post_process=self.post_process,
+            init_method_std=init_method_std,
+            use_cpu_initialization=use_cpu_initialization,
+            precision=precision,
+            fp32_residual_connection=fp32_residual_connection,
+            activations_checkpoint_granularity=activations_checkpoint_granularity,
+            activations_checkpoint_method=activations_checkpoint_method,
+            activations_checkpoint_num_layers=activations_checkpoint_num_layers,
+            activations_checkpoint_layers_per_pipeline=activations_checkpoint_layers_per_pipeline,
+            normalization=normalization,
+            layernorm_epsilon=layernorm_epsilon,
+            rotary_percentage=rotary_percentage,
+            share_embeddings_and_output_weights=share_embeddings_and_output_weights,
+            bias=bias,
+            bias_activation_fusion=bias_activation_fusion,
+            bias_dropout_add_fusion=bias_dropout_add_fusion,
+            masked_softmax_fusion=masked_softmax_fusion,
+            gradient_accumulation_fusion=gradient_accumulation_fusion,
+            activation=activation,
+            headscale=headscale,
+            transformer_block_type=transformer_block_type,
+            normalize_attention_scores=normalize_attention_scores,
+            position_embedding_type=position_embedding_type,
+            attention_type=attention_type,
+            persist_layer_norm=persist_layer_norm,
+            openai_gelu=openai_gelu,
+            onnx_safe=onnx_safe,
+            sequence_parallel=sequence_parallel,
+            transformer_engine=transformer_engine,
+            fp8=fp8,
+            fp8_e4m3=fp8_e4m3,
+            fp8_hybrid=fp8_hybrid,
+            fp8_margin=fp8_margin,
+            fp8_interval=fp8_interval,
+            fp8_amax_history_len=fp8_amax_history_len,
+            fp8_amax_compute_algo=fp8_amax_compute_algo,
+            reduce_amax=reduce_amax,
+            use_emha=use_emha,
+            position_interpolation_factor=position_interpolation_factor,
+        )
+
+        logging.trace(
+            f"In BigCodeModel._init_() leave get_language_model()", trace_type="recovery_time")
+
+        if self.share_embeddings_and_output_weights:
+            self.initialize_word_embeddings(
+                init_method=init_method_normal(init_method_std), vocab_size=vocab_size, hidden_size=hidden_size
+            )
+
+    def set_input_tensor(self, input_tensor):
+        """See megatron.model.transformer.set_input_tensor()"""
+        self.language_model.set_input_tensor(input_tensor)
+
+    def forward(
+        self,
+        input_ids,
+        position_ids,
+        attention_mask,
+        labels=None,
+        token_type_ids=None,
+        layer_past=None,
+        get_key_value=False,
+        forward_method_parallel_output=None,
+        encoder_input=None,
+        set_inference_key_value_memory=False,
+        inference_max_sequence_len=None,
+        checkpoint_activations_all_layers=None,
+    ):
+        # input_ids: [b, s]
+        # position_ids: [b, s]
+        # attention_mask: [1, 1, s, s]
+
+        lm_output = self.language_model(
+            input_ids,
+            position_ids,
+            attention_mask,
+            layer_past=layer_past,
+            get_key_value=get_key_value,
+            encoder_input=encoder_input,
+            set_inference_key_value_memory=set_inference_key_value_memory,
+            inference_max_sequence_len=inference_max_sequence_len,
+            checkpoint_activations_all_layers=checkpoint_activations_all_layers,
+        )
+        if self.post_process:
+            return post_language_model_processing(
+                lm_output,
+                labels,
+                self.language_model.output_layer.weight
+                if not self.share_embeddings_and_output_weights
+                else self.word_embeddings_weight(),
+                get_key_value,
+                self.parallel_output,
+                forward_method_parallel_output,
+                self.fp16_lm_cross_entropy,
+                return_logits=self.save_logits,
+                sequence_parallel=self.sequence_parallel,
+                gradient_accumulation_fusion=self.gradient_accumulation_fusion,
+                share_embeddings_and_output_weights=self.share_embeddings_and_output_weights
+            )
+        else:
+            return lm_output
+
+    def state_dict_for_save_checkpoint(self, destination=None, prefix='', keep_vars=False):
+
+        state_dict_ = {}
+        state_dict_[self._language_model_key] = self.language_model.state_dict_for_save_checkpoint(
+            destination, prefix, keep_vars
+        )
+        # Save word_embeddings.
+        if self.post_process and not self.pre_process:
+            state_dict_[self._word_embeddings_for_head_key] = self.word_embeddings.state_dict(
+                destination, prefix, keep_vars
+            )
+        return state_dict_
+
+    def load_state_dict(self, state_dict, strict=True):
+        """Customized load."""
+
+        # Load word_embeddings.
+        if self.post_process and not self.pre_process:
+            self.word_embeddings.load_state_dict(
+                state_dict[self._word_embeddings_for_head_key], strict=strict)
+        if self._language_model_key in state_dict:
+            state_dict = state_dict[self._language_model_key]
+        self.language_model.load_state_dict(state_dict, strict=strict)

--- a/nemo/nemo/collections/nlp/models/language_modeling/megatron_bigcode_model.py
+++ b/nemo/nemo/collections/nlp/models/language_modeling/megatron_bigcode_model.py
@@ -1,0 +1,86 @@
+from nemo.collections.nlp.models.language_modeling.megatron_gpt_model import MegatronGPTModel
+from omegaconf.dictconfig import DictConfig
+from pytorch_lightning import Trainer
+from nemo.collections.nlp.models.language_modeling.megatron.bigcode_model import BigCodeModel
+
+
+class MegatronBigCodeModel(MegatronGPTModel):
+    """
+        Pretrain BigCode Model without validation
+        """
+
+    def __init__(self, cfg: DictConfig, trainer: Trainer):
+        super().__init__(cfg, trainer)
+
+    def model_provider_func(self, pre_process, post_process):
+        """Model depends on pipeline paralellism."""
+        model = BigCodeModel(
+            vocab_size=self.padded_vocab_size,
+            hidden_size=self.cfg.hidden_size,
+            max_position_embeddings=self.cfg.max_position_embeddings,
+            num_layers=self.cfg.num_layers,
+            num_attention_heads=self.cfg.num_attention_heads,
+            apply_query_key_layer_scaling=self.cfg.get(
+                'apply_query_key_layer_scaling', True),
+            kv_channels=self.cfg.get('kv_channels', None),
+            ffn_hidden_size=self.cfg.ffn_hidden_size,
+            num_tokentypes=0,
+            parallel_output=True,
+            pre_process=pre_process,
+            post_process=post_process,
+            init_method_std=self.cfg.get('init_method_std', 0.02),
+            use_scaled_init_method=self.cfg.get(
+                'use_scaled_init_method', True),
+            fp16_lm_cross_entropy=self.cfg.get('fp16_lm_cross_entropy', False),
+            use_cpu_initialization=self.cfg.get(
+                'use_cpu_initialization', False),
+            hidden_dropout=self.cfg.get('hidden_dropout', 0.1),
+            attention_dropout=self.cfg.get('attention_dropout', 0.0),
+            ffn_dropout=self.cfg.get('ffn_dropout', 0.0),
+            precision=self.cfg.get('precision', 16),
+            fp32_residual_connection=self.cfg.get(
+                'fp32_residual_connection', False),
+            activations_checkpoint_granularity=self.cfg.get(
+                'activations_checkpoint_granularity', None),
+            activations_checkpoint_method=self.cfg.get(
+                'activations_checkpoint_method', None),
+            activations_checkpoint_num_layers=self.cfg.get(
+                'activations_checkpoint_num_layers', 1),
+            activations_checkpoint_layers_per_pipeline=self.cfg.get(
+                'activations_checkpoint_layers_per_pipeline', None
+            ),
+            normalization=self.cfg.get('normalization', 'layernorm'),
+            layernorm_epsilon=self.cfg.get('layernorm_epsilon', 1e-5),
+            onnx_safe=self.cfg.get('onnx_safe', False),
+            bias_activation_fusion=self.cfg.get(
+                'bias_activation_fusion', True),
+            bias_dropout_add_fusion=self.cfg.get(
+                'bias_dropout_add_fusion', True),
+            share_embeddings_and_output_weights=self.cfg.get(
+                'share_embeddings_and_output_weights', True),
+            position_embedding_type=self.cfg.get(
+                'position_embedding_type', 'learned_absolute'),
+            rotary_percentage=self.cfg.get('rotary_percentage', 1.0),
+            activation=self.cfg.get('activation', 'gelu'),
+            bias=self.cfg.get('has_bias', True),
+            transformer_block_type=self.cfg.get(
+                'transformer_block_type', 'pre_ln'),
+            masked_softmax_fusion=self.cfg.get('masked_softmax_fusion', True),
+            gradient_accumulation_fusion=self.cfg.get(
+                'gradient_accumulation_fusion', False),
+            persist_layer_norm=self.cfg.get('persist_layer_norm', False),
+            sequence_parallel=self.cfg.get('sequence_parallel', False),
+            transformer_engine=self.cfg.get('transformer_engine', False),
+            fp8=self.cfg.get('fp8', False),
+            fp8_e4m3=self.cfg.get('fp8_e4m3', False),
+            fp8_hybrid=self.cfg.get('fp8_hybrid', False),
+            fp8_margin=self.cfg.get('fp8_margin', 0),
+            fp8_interval=self.cfg.get('fp8_interval', 1),
+            fp8_amax_history_len=self.cfg.get('fp8_amax_history_len', 1),
+            fp8_amax_compute_algo=self.cfg.get(
+                'fp8_amax_compute_algo', 'most_recent'),
+            use_emha=self.cfg.get('use_emha', False),
+            save_logits=self.cfg.get('save_logits', False)
+        )
+
+        return model

--- a/nemo/nemo/collections/nlp/modules/common/megatron/bigcode_module.py
+++ b/nemo/nemo/collections/nlp/modules/common/megatron/bigcode_module.py
@@ -1,0 +1,3438 @@
+# coding=utf-8
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transformer."""
+import math
+from contextlib import nullcontext
+from typing import Any, Callable, Optional
+import datetime
+import torch
+import torch.nn.functional as F
+from einops import rearrange, repeat
+from nemo.collections.common.parts.adapter_modules import LinearAdapterConfig
+from nemo.collections.nlp.modules.common.megatron.adapters.parallel_adapters import (
+    AdapterName,
+    InfusedAdapterConfig,
+    MLPInfusedAdapterConfig,
+    ParallelLinearAdapterConfig,
+)
+from nemo.collections.nlp.modules.common.megatron.fused_bias_dropout_add import (
+    bias_dropout_add,
+    bias_dropout_add_fused_inference,
+    bias_dropout_add_fused_train,
+    dropout_add,
+)
+from nemo.collections.nlp.modules.common.megatron.fused_bias_geglu import fused_bias_geglu
+from nemo.collections.nlp.modules.common.megatron.fused_bias_gelu import fused_bias_gelu
+from nemo.collections.nlp.modules.common.megatron.fused_layer_norm import get_layer_norm
+from nemo.collections.nlp.modules.common.megatron.fused_softmax import MatchedScaleMaskSoftmax
+from nemo.collections.nlp.modules.common.megatron.layer_norm_1p import LayerNorm1P
+from nemo.collections.nlp.modules.common.megatron.layer_type import LayerType
+from nemo.collections.nlp.modules.common.megatron.module import MegatronModule
+from nemo.collections.nlp.modules.common.megatron.rotary_pos_embedding import RotaryEmbedding, apply_rotary_pos_emb
+from nemo.collections.nlp.modules.common.megatron.utils import ApexGuardDefaults, attention_mask_func, erf_gelu, get_linear_layer
+from nemo.collections.nlp.modules.common.megatron.utils import openai_gelu as openai_gelu_func
+from nemo.core import adapter_mixins
+from nemo.utils import logging
+from transformers.utils import is_torch_tpu_available
+
+try:
+    from apex.transformer import parallel_state, tensor_parallel
+    from apex.transformer.enums import AttnMaskType, AttnType, ModelType
+    from apex.transformer.utils import divide as safe_divide
+    from apex.transformer.parallel_state import get_tensor_model_parallel_world_size
+    # from apex.normalization import MixedFusedRMSNorm
+    from apex.transformer.layers.layer_norm import FastRMSNorm as MixedFusedRMSNorm
+    from apex.transformer.functional.fused_softmax import FusedScaleMaskSoftmax
+
+    HAVE_APEX = True
+
+except (ImportError, ModuleNotFoundError):
+
+    HAVE_APEX = False
+
+    # fake missing classes with None attributes
+    ModelType = AttnMaskType = AttnType = LayerType = ApexGuardDefaults()
+
+try:
+    from transformer_engine.pytorch import TransformerLayer, fp8_autocast
+    from transformer_engine.common import recipe
+    from transformer_engine.pytorch.distributed import checkpoint as te_checkpoint
+
+    HAVE_TE = True
+
+except:
+    HAVE_TE = False
+
+    # fake missing class
+    class TransformerLayer(ApexGuardDefaults):
+        def __init__(self):
+            super().__init__()
+
+            logging.warning(
+                "Transformer Engine was not found. transformer_engine.pytorch.transformer.TransformerLayer will not work. Please see the NeMo README for installation instructions: https://github.com/NVIDIA/NeMo#megatron-gpt."
+            )
+
+""" We use the following notation throughout this file:
+     h: hidden size
+     n: number of attention heads
+     p: number of model parallel partitions
+     np: n/p
+     hp: h/p
+     hn: h/n
+     b: batch size
+     s: sequence length
+     l: number of layers
+    Transformer takes input of size [s, b, h] and returns a
+    tensor of the same size. We use the following arguments:
+        hyperparameters: transformer hyperparameters
+"""
+
+
+class ParallelMLP(MegatronModule, adapter_mixins.AdapterModuleMixin):
+    """MLP.
+
+    MLP will take the input with h hidden state, project it to 4*h
+    hidden dimension, perform nonlinear transformation, and project the
+    state back into h hidden dimension.
+    """
+
+    def __init__(
+        self,
+        init_method,
+        output_layer_init_method,
+        hidden_size,
+        ffn_hidden_size,
+        use_cpu_initialization=False,
+        bias_activation_fusion=True,
+        openai_gelu=False,
+        onnx_safe=False,
+        activation='gelu',
+        bias=True,
+        transformer_block_type='pre_ln',
+        normalization='layernorm',
+        layernorm_epsilon=1e-5,
+        persist_layer_norm=False,
+        sequence_parallel=False,
+        gradient_accumulation_fusion=False,
+        dropout=0.0,
+        transfer_with_static_ring=True,
+    ):
+        super(ParallelMLP, self).__init__()
+        self.activation = activation
+        self.bias = bias
+        self.transformer_block_type = transformer_block_type
+        self.normalization = normalization
+        self.layernorm_epsilon = layernorm_epsilon
+        self.persist_layer_norm = persist_layer_norm
+        self.activation = activation
+        self.dropout = dropout
+        self.set_accepted_adapter_types([MLPInfusedAdapterConfig._target_])
+
+        if activation not in ['gelu', 'geglu', 'reglu', 'swiglu']:
+            raise ValueError(
+                f"Activation {activation} not supported. Only gelu, geglu, reglu, swiglu are supported.")
+
+        no_async_tensor_model_parallel_allreduce = (
+            parallel_state.get_tensor_model_parallel_world_size() == 1 or sequence_parallel
+        )
+        t0 = datetime.datetime.now()
+        # Project to 4h.
+        self.dense_h_to_4h = tensor_parallel.ColumnParallelLinear(
+            hidden_size,
+            # NOTE: When using geglu, divide ffn dim by 2/3 to keep overall params the same.
+            ffn_hidden_size,
+            gather_output=False,
+            init_method=init_method,
+            skip_bias_add=True,
+            use_cpu_initialization=use_cpu_initialization,
+            bias=bias,
+            sequence_parallel_enabled=sequence_parallel,
+            no_async_tensor_model_parallel_allreduce=no_async_tensor_model_parallel_allreduce,
+            gradient_accumulation_fusion=gradient_accumulation_fusion,
+            transfer_with_static_ring=transfer_with_static_ring,
+        )
+        t1 = datetime.datetime.now()
+        logging.trace(
+            f"In ParallelMLP  create self.dense_h_to_4h. Begin: {t0} Elapsed: {(t1 - t0).total_seconds()} s.", trace_type="recovery_time")
+
+        if activation in ['geglu', 'reglu', 'swiglu']:
+            # Separate linear layer for *GLU activations.
+            # Source: https://github.com/huggingface/transformers/blob/bee361c6f1f7704f8c688895f2f86f6e5ff84727/src/transformers/models/t5/modeling_t5.py#L292
+            t0 = datetime.datetime.now()
+            self.dense_h_to_4h_2 = tensor_parallel.ColumnParallelLinear(
+                hidden_size,
+                # NOTE: When using *glu, divide ffn dim by 2/3 to keep overall params the same.
+                ffn_hidden_size,
+                gather_output=False,
+                init_method=init_method,
+                skip_bias_add=True,
+                use_cpu_initialization=use_cpu_initialization,
+                bias=bias,
+                sequence_parallel_enabled=sequence_parallel,
+                no_async_tensor_model_parallel_allreduce=no_async_tensor_model_parallel_allreduce,
+                gradient_accumulation_fusion=gradient_accumulation_fusion,
+                transfer_with_static_ring=transfer_with_static_ring,
+            )
+            t1 = datetime.datetime.now()
+            logging.trace(
+                f"In ParallelMLP create self.dense_h_to_4h_2. Begin: {t0} Elapsed: {(t1 - t0).total_seconds()} s.", trace_type="recovery_time")
+
+        self.glu_activation_family = activation in ['geglu', 'reglu', 'swiglu']
+        bias_activation_fusion_unavailable = activation in ['reglu', 'swiglu']
+
+        if bias_activation_fusion_unavailable and bias_activation_fusion:
+            raise ValueError(
+                f"Cannot use bias_activation_fusion with {activation} activation. Please turn bias gelu fusion off."
+            )
+
+        if self.glu_activation_family and onnx_safe and self.bias_activation_fusion:
+            raise ValueError(
+                f"Cannot use onnx_safe with specificed activation function and bias_activation_fusion : {activation} Please turn onnx safe off."
+            )
+
+        if bias_activation_fusion and not bias:
+            raise ValueError(
+                f"Cannot use bias_activation_fusion without bias terms. Please set bias=True or bias_activation_fusion=False."
+            )
+
+        self.bias_activation_fusion = bias_activation_fusion
+
+        # Give openai_gelu precedence over other activations if set, for HF compatibility. Normally this is off and shouldn't affect regular model training.
+        if openai_gelu:
+            self.activation_func = openai_gelu_func
+        elif activation in ["gelu", "geglu"]:
+            self.activation_func = F.gelu
+        elif onnx_safe:
+            self.activation_func = erf_gelu
+        elif activation == "reglu":
+            self.activation_func = F.relu
+        elif activation == "swiglu":
+            # SiLU or sigmoid linear unit is the same as swish with beta = 1 (which is what https://arxiv.org/pdf/2002.05202.pdf uses.)
+            self.activation_func = F.silu
+
+        # Project back to h.
+        t0 = datetime.datetime.now()
+        self.dense_4h_to_h = tensor_parallel.RowParallelLinear(
+            ffn_hidden_size,
+            hidden_size,
+            input_is_parallel=True,
+            init_method=output_layer_init_method,
+            skip_bias_add=True,
+            use_cpu_initialization=use_cpu_initialization,
+            bias=bias,
+            sequence_parallel_enabled=sequence_parallel,
+            gradient_accumulation_fusion=gradient_accumulation_fusion,
+            transfer_with_static_ring=transfer_with_static_ring,
+        )
+        t1 = datetime.datetime.now()
+        logging.trace(
+            f"In ParallelMLP create self.dense_4h_to_h. Begin: {t0} Elapsed: {(t1 - t0).total_seconds()} s.", trace_type="recovery_time")
+
+        # Normformer normalization
+        if transformer_block_type == 'normformer':
+            if normalization == 'layernorm':
+                self.normalization = get_layer_norm(
+                    ffn_hidden_size // get_tensor_model_parallel_world_size(), layernorm_epsilon, persist_layer_norm
+                )
+            elif normalization == 'layernorm1p':
+                self.normalization = LayerNorm1P(
+                    ffn_hidden_size // get_tensor_model_parallel_world_size(),
+                    layernorm_epsilon,
+                    sequence_parallel_enabled=sequence_parallel,
+                )
+            else:
+                self.normalization = MixedFusedRMSNorm(
+                    ffn_hidden_size // get_tensor_model_parallel_world_size(), layernorm_epsilon,
+                    sequence_parallel_enabled=sequence_parallel
+                )
+
+    def forward(self, hidden_states):
+
+        # [s, b, 4hp]
+        intermediate_parallel, bias_parallel = self.dense_h_to_4h(
+            hidden_states)
+
+        if self.glu_activation_family:
+            intermediate_parallel_2, bias_parallel_2 = self.dense_h_to_4h_2(
+                hidden_states)
+
+        if self.bias_activation_fusion:
+            if self.activation == 'gelu':
+                intermediate_parallel = fused_bias_gelu(
+                    intermediate_parallel, bias_parallel)
+            elif self.activation == 'geglu':
+                intermediate_parallel = fused_bias_geglu(
+                    intermediate_parallel, bias_parallel, intermediate_parallel_2, bias_parallel_2
+                )
+
+        elif self.activation in ['reglu', 'swiglu'] or (
+            self.glu_activation_family and not self.bias_activation_fusion
+        ):
+            if bias_parallel is not None:
+                intermediate_parallel = self.activation_func(intermediate_parallel + bias_parallel) * (
+                    intermediate_parallel_2 + bias_parallel_2
+                )
+            else:
+                intermediate_parallel = self.activation_func(
+                    intermediate_parallel) * intermediate_parallel_2
+
+        else:
+            if bias_parallel is not None:
+                intermediate_parallel = self.activation_func(
+                    intermediate_parallel + bias_parallel)
+            else:
+                intermediate_parallel = self.activation_func(
+                    intermediate_parallel)
+
+        if self.dropout > 0:
+            intermediate_parallel = F.dropout(
+                intermediate_parallel, p=self.dropout, training=self.training)
+
+        infused_adapter = self.get_from_adapter_layer(AdapterName.MLP_INFUSED)
+        if infused_adapter:
+            intermediate_parallel = infused_adapter(intermediate_parallel)
+
+        # Normformer normalization
+        if self.transformer_block_type == 'normformer':
+            intermediate_parallel = self.normalization(intermediate_parallel)
+
+        # [s, b, h]
+        output, output_bias = self.dense_4h_to_h(intermediate_parallel)
+        return output, output_bias
+
+
+class SwitchMLP(MegatronModule):
+    """Top-1 MoE
+
+    Curently supports Sinkhorn based expert routing."""
+
+    def __init__(
+        self,
+        num_experts,
+        init_method,
+        output_layer_init_method,
+        hidden_size,
+        ffn_hidden_size,
+        use_cpu_initialization=False,
+        bias_activation_fusion=True,
+        openai_gelu=False,
+        onnx_safe=False,
+        activation='gelu',
+        bias=True,
+        transformer_block_type='pre_ln',
+        normalization='layernorm',
+        layernorm_epsilon=1e-5,
+        persist_layer_norm=False,
+        sequence_parallel=False,
+        gradient_accumulation_fusion=False,
+        dropout=0.0,
+    ):
+        super(SwitchMLP, self).__init__()
+
+        self.num_experts = num_experts
+        self.route_algo = SwitchMLP.sinkhorn
+        self.router = tensor_parallel.RowParallelLinear(
+            hidden_size,
+            num_experts,
+            input_is_parallel=False,
+            init_method=init_method,
+            skip_bias_add=False,
+            use_cpu_initialization=use_cpu_initialization,
+            bias=bias,
+            sequence_parallel_enabled=sequence_parallel,
+            gradient_accumulation_fusion=gradient_accumulation_fusion,
+        )
+
+        mlp_args = {
+            'init_method': init_method,
+            'output_layer_init_method': output_layer_init_method,
+            'hidden_size': hidden_size,
+            'ffn_hidden_size': ffn_hidden_size,
+            'use_cpu_initialization': use_cpu_initialization,
+            'bias_activation_fusion': bias_activation_fusion,
+            'openai_gelu': openai_gelu,
+            'onnx_safe': onnx_safe,
+            'activation': activation,
+            'bias': bias,
+            'transformer_block_type': transformer_block_type,
+            'normalization': normalization,
+            'layernorm_epsilon': layernorm_epsilon,
+            'persist_layer_norm': persist_layer_norm,
+            'sequence_parallel': sequence_parallel,
+            'gradient_accumulation_fusion': gradient_accumulation_fusion,
+            'dropout': dropout,
+        }
+        self.experts = torch.nn.ModuleList(
+            [ParallelMLP(**mlp_args) for _ in range(num_experts)])
+
+    def forward(self, hidden_states):
+        hidden_shape = hidden_states.shape
+        route, _ = self.router(hidden_states)
+        route = route.view(-1, self.num_experts)
+        if self.training:
+            with torch.no_grad():
+                norm_route = self.route_algo(
+                    route.detach().to(dtype=torch.float32)
+                )  # explicit fp32 conversion for stability
+                _, max_ind = torch.max(norm_route, dim=1)
+            route = torch.sigmoid(route)
+            max_prob = route[torch.arange(route.size(0)), max_ind]
+        else:
+            route = torch.sigmoid(route)
+            max_prob, max_ind = torch.max(route, dim=1)
+        max_prob = torch.unsqueeze(max_prob, 1)
+
+        hidden_states = hidden_states.view(-1, hidden_shape[-1])
+
+        local_indices = (max_ind == 0).nonzero()
+        hidden = hidden_states[local_indices, :]
+        output, output_bias = self.experts[0](hidden)
+        output_bias = output_bias.expand_as(output)
+
+        output_total = torch.empty_like(hidden_states, dtype=output.dtype)
+        output_bias_total = torch.empty_like(
+            hidden_states, dtype=output_bias.dtype)
+
+        output_total[local_indices, :] = output
+        output_bias_total[local_indices, :] = output_bias
+
+        for expert_num, expert in enumerate(self.experts):
+            if expert_num == 0:
+                continue
+            local_indices = (max_ind == expert_num).nonzero()
+            hidden = hidden_states[local_indices, :]
+            output, output_bias = expert(hidden)
+            output_bias = output_bias.expand_as(output)
+            output_total[local_indices, :] = output
+            output_bias_total[local_indices, :] = output_bias
+
+        output_total = output_total * max_prob
+        output_bias_total = output_bias_total * max_prob
+        output_total = output_total.view(hidden_shape)
+        output_bias_total = output_bias_total.view(hidden_shape)
+
+        return output_total, output_bias_total
+
+    @classmethod
+    def sinkhorn(cls, cost, tol=0.0001):
+        "Megatron-LMs sinkhorn implementation"
+
+        cost = torch.exp(cost)
+        d0 = torch.ones(cost.size(0), device=cost.device, dtype=cost.dtype)
+        d1 = torch.ones(cost.size(1), device=cost.device, dtype=cost.dtype)
+
+        eps = 0.00000001
+        error = 1e9
+        d1_old = d1
+        while error > tol:
+            d0 = (1 / d0.size(0)) * 1 / (torch.sum(d1 * cost, 1) + eps)
+            d1 = (1 / d1.size(0)) * 1 / \
+                (torch.sum(d0.unsqueeze(1) * cost, 0) + eps)
+            error = torch.mean(torch.abs(d1_old - d1))
+            d1_old = d1
+        return d1 * cost * d0.unsqueeze(1)
+
+
+class Embedding(MegatronModule):
+    """Language model embeddings.
+
+    Arguments:
+        hidden_size: hidden size
+        vocab_size: vocabulary size
+        max_sequence_length: maximum size of sequence. This
+                             is used for positional embedding
+        embedding_dropout_prob: dropout probability for embeddings
+        init_method: weight initialization method
+        num_tokentypes: size of the token-type embeddings. 0 value
+                        will ignore this embedding
+        use_cpu_initialization: whether to initialize the weights in CPU
+        position_embedding_type: position embedding type determines whether we instantiate a learnable position embedding table.
+    """
+
+    def __init__(
+        self,
+        hidden_size,
+        vocab_size,
+        max_sequence_length,
+        embedding_dropout_prob,
+        init_method,
+        num_tokentypes=0,
+        use_cpu_initialization=False,
+        fp32_residual_connection=False,
+        sequence_parallel=False,
+        position_embedding_type='learned_absolute',
+        transpose_batch_sequence=True,
+    ):
+        super(Embedding, self).__init__()
+
+        self.hidden_size = hidden_size
+        self.init_method = init_method
+        self.num_tokentypes = num_tokentypes
+        self.position_embedding_type = position_embedding_type
+        self.transpose_batch_sequence = transpose_batch_sequence
+
+        # Word embeddings (parallel).
+        self.word_embeddings = tensor_parallel.VocabParallelEmbedding(
+            vocab_size, self.hidden_size, init_method=self.init_method, use_cpu_initialization=use_cpu_initialization,
+        )
+        self._word_embeddings_key = 'word_embeddings'
+
+        if self.position_embedding_type == 'learned_absolute':
+            # Position embedding (serial).
+            self.position_embeddings = torch.nn.Embedding(
+                max_sequence_length, self.hidden_size)
+            self._position_embeddings_key = 'position_embeddings'
+            # Initialize the position embeddings.
+            self.init_method(self.position_embeddings.weight)
+
+        # Token type embedding.
+        # Add this as an optional field that can be added through
+        # method call so we can load a pretrain model without
+        # token types and add them as needed.
+        self._tokentype_embeddings_key = 'tokentype_embeddings'
+        if self.num_tokentypes > 0:
+            self.tokentype_embeddings = torch.nn.Embedding(
+                self.num_tokentypes, self.hidden_size)
+            # Initialize the token-type embeddings.
+            self.init_method(self.tokentype_embeddings.weight)
+        else:
+            self.tokentype_embeddings = None
+
+        self.fp32_residual_connection = fp32_residual_connection
+        self.sequence_parallel = sequence_parallel
+
+        # Embeddings dropout
+        self.embedding_dropout = torch.nn.Dropout(embedding_dropout_prob)
+
+    def zero_parameters(self):
+        """Zero out all parameters in embedding."""
+        self.word_embeddings.weight.data.fill_(0)
+        self.word_embeddings.weight.shared = True
+        if self.position_embedding_type == 'learned_absolute':
+            self.position_embeddings.weight.data.fill_(0)
+            self.position_embeddings.weight.shared = True
+        if self.num_tokentypes > 0:
+            self.tokentype_embeddings.weight.data.fill_(0)
+            self.tokentype_embeddings.weight.shared = True
+
+    def add_tokentype_embeddings(self, num_tokentypes):
+        """Add token-type embedding. This function is provided so we can add
+        token-type embeddings in case the pretrained model does not have it.
+        This allows us to load the model normally and then add this embedding.
+        """
+        if self.tokentype_embeddings is not None:
+            raise Exception('tokentype embeddings is already initialized')
+        if torch.distributed.get_rank() == 0:
+            print('adding embedding for {} tokentypes'.format(
+                num_tokentypes), flush=True)
+        self.num_tokentypes = num_tokentypes
+        self.tokentype_embeddings = torch.nn.Embedding(
+            num_tokentypes, self.hidden_size)
+        # Initialize the token-type embeddings.
+        self.init_method(self.tokentype_embeddings.weight)
+
+    def forward(self, input_ids, position_ids=None, token_type_ids=None):
+        # Embeddings.
+        words_embeddings = self.word_embeddings(input_ids)
+        if self.position_embedding_type == 'learned_absolute':
+            assert position_ids is not None
+            position_embeddings = self.position_embeddings(position_ids)
+            embeddings = words_embeddings + position_embeddings
+        else:
+            embeddings = words_embeddings
+        if token_type_ids is not None:
+            assert self.tokentype_embeddings is not None
+            embeddings = embeddings + self.tokentype_embeddings(token_type_ids)
+        else:
+            assert self.tokentype_embeddings is None
+
+        # Data format change to avoid explicit tranposes : [b s h] --> [s b h].
+        if self.transpose_batch_sequence:
+            embeddings = embeddings.transpose(0, 1).contiguous()
+
+        # If the input flag for fp32 residual connection is set, convert for float.
+        if self.fp32_residual_connection:
+            embeddings = embeddings.float()
+
+        # Dropout.
+        if self.sequence_parallel:
+            embeddings = tensor_parallel.mappings.scatter_to_sequence_parallel_region(
+                embeddings)
+            with tensor_parallel.random.get_xla_rng_tracker().fork():
+                embeddings = self.embedding_dropout(embeddings)
+        else:
+            embeddings = self.embedding_dropout(embeddings)
+
+        return embeddings
+
+    def state_dict_for_save_checkpoint(self, destination=None, prefix='', keep_vars=False):
+        """For easy load."""
+
+        state_dict_ = {}
+        state_dict_[self._word_embeddings_key] = self.word_embeddings.state_dict(
+            destination, prefix, keep_vars)
+        if self.position_embedding_type == 'learned_absolute':
+            state_dict_[self._position_embeddings_key] = self.position_embeddings.state_dict(
+                destination, prefix, keep_vars
+            )
+        if self.num_tokentypes > 0:
+            state_dict_[self._tokentype_embeddings_key] = self.tokentype_embeddings.state_dict(
+                destination, prefix, keep_vars
+            )
+
+        return state_dict_
+
+    def load_state_dict(self, state_dict, strict=True):
+        """Customized load."""
+
+        # Word embedding.
+        if self._word_embeddings_key in state_dict:
+            state_dict_ = state_dict[self._word_embeddings_key]
+        else:
+            # for backward compatibility.
+            state_dict_ = {}
+            for key in state_dict.keys():
+                if 'word_embeddings' in key:
+                    state_dict_[key.split('word_embeddings.')[
+                        1]] = state_dict[key]
+        self.word_embeddings.load_state_dict(state_dict_, strict=strict)
+
+        if self.position_embedding_type == 'learned_absolute':
+            # Position embedding.
+            if self._position_embeddings_key in state_dict:
+                state_dict_ = state_dict[self._position_embeddings_key]
+            else:
+                # for backward compatibility.
+                state_dict_ = {}
+                for key in state_dict.keys():
+                    if 'position_embeddings' in key:
+                        state_dict_[key.split('position_embeddings.')[
+                            1]] = state_dict[key]
+            self.position_embeddings.load_state_dict(
+                state_dict_, strict=strict)
+
+        # Tokentype embedding.
+        if self.num_tokentypes > 0:
+            state_dict_ = {}
+            if self._tokentype_embeddings_key in state_dict:
+                state_dict_ = state_dict[self._tokentype_embeddings_key]
+            else:
+                # for backward compatibility.
+                for key in state_dict.keys():
+                    if 'tokentype_embeddings' in key:
+                        state_dict_[key.split('tokentype_embeddings.')[
+                            1]] = state_dict[key]
+            if len(state_dict_.keys()) > 0:
+                self.tokentype_embeddings.load_state_dict(
+                    state_dict_, strict=strict)
+            else:
+                print(
+                    '***WARNING*** expected tokentype embeddings in the ' 'checkpoint but could not find it',
+                    flush=True,
+                )
+
+
+class CoreAttention(MegatronModule):
+    """ Region where selective activation recomputation is applied.
+        See Figure 3. in Reducing Activation Recomputation in Large Transformer Models
+        https://arxiv.org/pdf/2205.05198.pdf for more details.
+
+    """
+
+    def __init__(
+        self,
+        layer_number,
+        num_attention_heads,
+        hidden_size,
+        attention_type=AttnType.self_attn,
+        attn_mask_type=AttnMaskType.padding,
+        precision=16,
+        apply_query_key_layer_scaling=True,
+        kv_channels=None,
+        masked_softmax_fusion=True,
+        attention_dropout=0.1,
+        sequence_parallel=False,
+        normalize_attention_scores=True,
+        multi_query_attention=False,
+        position_embedding_type='learned_absolute',
+        position_interpolation_factor=1.0,
+        max_position_embeddings=4096,
+        rotary_percentage=1.0,
+    ):
+
+        super(CoreAttention, self).__init__()
+
+        self.precision = precision
+        self.fp16 = precision == 16
+        self.bf16 = precision == 'bf16'
+        self.multi_query_attention = multi_query_attention
+
+        self.apply_query_key_layer_scaling = apply_query_key_layer_scaling
+        self.attention_softmax_in_fp32 = False
+        if self.apply_query_key_layer_scaling:
+            self.attention_softmax_in_fp32 = True
+        self.layer_number = max(1, layer_number)
+        self.attention_type = attention_type
+        self.attn_mask_type = attn_mask_type
+        self.sequence_parallel = sequence_parallel
+        # If True, will scale attention scores by 1 / sqrt(hidden_size_per_attention_head).
+        # This arg is been provided mostly to support weight conversion of Huggingface models. (ex: T5v1.1)
+        self.normalize_attention_scores = normalize_attention_scores
+        self.position_embedding_type = position_embedding_type
+        self.position_interpolation_factor = position_interpolation_factor
+        self.rotary_percentage = rotary_percentage
+        if kv_channels is None:
+            assert (
+                hidden_size % num_attention_heads == 0
+            ), 'hidden_size must be divisible by num_attention_heads if kv_channels is None'
+            kv_channels = hidden_size // num_attention_heads
+
+        projection_size = kv_channels * num_attention_heads
+
+        # Per attention head and per partition values.
+        world_size = parallel_state.get_tensor_model_parallel_world_size()
+        self.hidden_size_per_partition = safe_divide(
+            projection_size, world_size)
+        self.hidden_size_per_attention_head = safe_divide(
+            projection_size, num_attention_heads)
+        self.num_attention_heads_per_partition = safe_divide(
+            num_attention_heads, world_size)
+        self.num_attention_heads_partition_offset = (
+            self.num_attention_heads_per_partition *
+            parallel_state.get_tensor_model_parallel_rank()
+        )
+
+        coeff = None
+        self.norm_factor = math.sqrt(self.hidden_size_per_attention_head)
+        if self.apply_query_key_layer_scaling:
+            coeff = self.layer_number
+            self.norm_factor *= coeff
+
+        self.scale_mask_softmax = FusedScaleMaskSoftmax(
+            self.fp16,
+            self.bf16,
+            self.attn_mask_type,
+            masked_softmax_fusion,
+            attention_mask_func,
+            self.attention_softmax_in_fp32,
+            coeff,
+        )
+
+        if self.position_embedding_type == 'rope':
+            self.rotary_emb = RotaryEmbedding(self.hidden_size_per_attention_head,
+                                              max_position_embeddings=max_position_embeddings,
+                                              position_interpolation_factor=self.position_interpolation_factor,
+                                              rotary_percentage=self.rotary_percentage)
+
+        # Dropout. Note that for a single iteration, this layer will generate
+        # different outputs on different number of parallel partitions but
+        # on average it should not be partition dependent.
+        self.attention_dropout = torch.nn.Dropout(attention_dropout)
+
+
+class MultiQueryCoreAttention(CoreAttention):
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    def forward(
+        self,
+        query_layer,
+        key_layer,
+        value_layer,
+        attention_mask,
+        layer_past=None,
+        get_key_value=False,
+        rotary_pos_emb=None,
+        relative_position_bias=None,
+        headscale_tensor=None,
+    ):
+        # ===================================
+        # Raw attention scores. [b, np, s, s]
+        # ===================================
+        sq = query_layer.size(0)
+        bs = query_layer.size(1)
+        np = query_layer.size(2)
+
+        sk = key_layer.size(0)
+        # Only one head for key and values
+        assert key_layer.size(2) == 1 and value_layer.size(2) == 1
+
+        # [b, np, sq, sk]
+        output_size = (query_layer.size(1),
+                       query_layer.size(2),
+                       query_layer.size(0),
+                       key_layer.size(0))
+
+        if self.position_embedding_type == 'rope':
+            # [sq, b, np, hn] --> [b, np, sq, hn] TODO optimize the permute of dimension back and forth
+            query_layer = query_layer.permute(1, 2, 0, 3)
+            key_layer = key_layer.permute(1, 2, 0, 3)
+            value_layer = value_layer.permute(1, 2, 0, 3)
+
+            cos, sin = self.rotary_emb(
+                value_layer, seq_len=query_layer.shape[2])
+            query_layer, key_layer = apply_rotary_pos_emb(
+                query_layer, key_layer, cos, sin, offset=0)
+
+            # [b, np, sq, hn] --> [sq, b, np, hn] TODO optimize the permute of dimension back and forth
+            query_layer = query_layer.permute(2, 0, 1, 3).contiguous()
+            key_layer = key_layer.permute(2, 0, 1, 3).contiguous()
+            value_layer = value_layer.permute(2, 0, 1, 3).contiguous()
+
+        # [sq, b, np, hn] -> [b, np * sq, hn]
+        query_layer = rearrange(query_layer, 'sq b np hn -> b (np sq) hn')
+        # [sk, b, 1, hn] -> [b, hn, sk]
+        key_layer = rearrange(key_layer, 'sk b 1 hn -> b hn sk')
+        # [sk, b, 1, hn] -> [b, sk, hn]
+        value_layer = rearrange(value_layer, 'sk b 1 hn -> b sk hn')
+        # [sk, b, 1, hn] -> [sk, b * np, hn]
+        # key_layer = key_layer.expand(output_size[3], output_size[0], np, -1)
+        # key_layer = key_layer.reshape(output_size[3], output_size[0] * np, -1)
+
+        # preallocting input tensor: [b, np * sq, sk]
+        matmul_input_buffer = torch.empty(
+            query_layer.shape[0],
+            query_layer.shape[1],
+            key_layer.shape[2],
+            dtype=query_layer.dtype,
+            device=query_layer.device,
+        )
+        matmul_result = torch.baddbmm(
+            matmul_input_buffer,
+            query_layer,
+            key_layer,
+            beta=0.0,
+            alpha=(1.0 / self.norm_factor) if self.normalize_attention_scores else 1.0,
+        )
+
+        # change view to [b, np, sq, sk]
+        attention_scores = matmul_result.view(*output_size)
+
+        if relative_position_bias is not None:
+            attention_scores += relative_position_bias[
+                :,
+                self.num_attention_heads_partition_offset: self.num_attention_heads_partition_offset
+                + self.num_attention_heads_per_partition,
+                : attention_scores.size(2),
+                : attention_scores.size(3),
+            ]
+
+        # ==================================================
+        # Update attention mask for inference. [b, np, sq, sk]
+        # ==================================================
+
+        if get_key_value:
+            with torch.no_grad():
+                if layer_past is not None:
+                    attention_mask = attention_mask[
+                        ..., attention_scores.size(3) - 1, : attention_scores.size(3)
+                    ].unsqueeze(2)
+                else:
+                    attention_mask = attention_mask[..., : attention_scores.size(
+                        3), : attention_scores.size(3)]
+
+        # ===========================
+        # Attention probs and dropout
+        # ===========================
+
+        # attention scores and attention mask [b, np, sq, sk]
+        attention_probs = self.scale_mask_softmax(attention_scores,
+                                                  attention_mask)
+
+        # This is actually dropping out entire tokens to attend to, which might
+        # seem a bit unusual, but is taken from the original Transformer paper.
+
+        if not self.sequence_parallel:
+            with tensor_parallel.random.get_xla_rng_tracker().fork():
+                attention_probs = self.attention_dropout(attention_probs)
+        else:
+            attention_probs = self.attention_dropout(attention_probs)
+
+        # =========================
+        # Context layer. [sq, b, hp]
+        # =========================
+
+        # value_layer -> context layer.
+        # [sk, b, np, hn] --> [b, np, sq, hn]
+
+        # change view [b * np, sq, sk]
+        attention_probs = rearrange(
+            attention_probs, 'b np sq sk -> b (np sq) sk')
+
+        # change view [b, np * sq, sk]
+        attention_probs = attention_probs.view(bs, np * sq, -1)
+
+        # matmul: [b, (np * sq), sk] * [b, sk, hn] = [b, np * sq, hn]
+        context_layer = torch.bmm(attention_probs, value_layer)
+        # change view [b, np, sq, hn]
+        context_layer = rearrange(
+            context_layer, 'b (np sq) hn -> b np sq hn', np=np)
+
+        if headscale_tensor is not None:
+            context_layer = context_layer * headscale_tensor
+
+        # [b, np, sq, hn] --> [sq, b, np, hn]
+        context_layer = context_layer.permute(2, 0, 1, 3).contiguous()
+
+        # [sq, b, np, hn] --> [sq, b, hp]
+        new_context_layer_shape = context_layer.size(
+        )[:-2] + (self.hidden_size_per_partition,)
+        context_layer = context_layer.view(*new_context_layer_shape)
+
+        return context_layer
+
+
+class ParallelAttention(MegatronModule, adapter_mixins.AdapterModuleMixin):
+    """Parallel self-attention layer abstract class.
+
+    Self-attention layer takes input with size [s, b, h]
+    and returns output of the same size.
+    """
+
+    def __init__(
+        self,
+        init_method,
+        output_layer_init_method,
+        layer_number,
+        num_attention_heads,
+        hidden_size,
+        attention_type=AttnType.self_attn,
+        attn_mask_type=AttnMaskType.padding,
+        precision=16,
+        apply_query_key_layer_scaling=True,
+        kv_channels=None,
+        use_cpu_initialization=False,
+        masked_softmax_fusion=True,
+        attention_dropout=0.1,
+        layer_type=None,
+        megatron_legacy=False,
+        bias=True,
+        headscale=False,
+        position_embedding_type='learned_absolute',
+        multi_query_attention=False,
+        activations_checkpoint_granularity=None,
+        sequence_parallel=False,
+        gradient_accumulation_fusion=False,
+        normalize_attention_scores=True,
+        transfer_with_static_ring=True,
+        position_interpolation_factor=1.0,
+        max_position_embeddings=4096,
+        rotary_percentage=1.0,
+    ):
+        super(ParallelAttention, self).__init__()
+        self.sequence_parallel = sequence_parallel
+        self.layer_number = max(1, layer_number)
+        self.attention_type = attention_type
+        self.attn_mask_type = attn_mask_type
+        self.normalize_attention_scores = normalize_attention_scores
+        self.position_embedding_type = position_embedding_type
+        self.position_interpolation_factor = position_interpolation_factor
+        self.rotary_percentage = rotary_percentage
+        self.multi_query_attention = multi_query_attention
+
+        self.megatron_legacy = megatron_legacy
+
+        self.set_accepted_adapter_types([InfusedAdapterConfig._target_])
+
+        if kv_channels is None:
+            assert (
+                hidden_size % num_attention_heads == 0
+            ), 'hidden_size must be divisible by num_attention_heads if kv_channels is None'
+            kv_channels = hidden_size // num_attention_heads
+        projection_size = kv_channels * num_attention_heads
+
+        # Per attention head and per partition values.
+        world_size = parallel_state.get_tensor_model_parallel_world_size()
+        self.hidden_size_per_attention_head = safe_divide(
+            projection_size, num_attention_heads)
+        self.num_attention_heads_per_partition = safe_divide(
+            num_attention_heads, world_size)
+        self.num_attention_heads_partition_offset = (
+            self.num_attention_heads_per_partition *
+            parallel_state.get_tensor_model_parallel_rank()
+        )
+
+        no_async_tensor_model_parallel_allreduce = (
+            parallel_state.get_tensor_model_parallel_world_size() == 1 or sequence_parallel
+        )
+
+        assert attention_type == AttnType.self_attn
+        # Strided linear layer.
+        t0 = datetime.datetime.now()
+        self.query = tensor_parallel.ColumnParallelLinear(
+            hidden_size,
+            projection_size,
+            gather_output=False,
+            init_method=init_method,
+            use_cpu_initialization=use_cpu_initialization,
+            bias=bias,
+            sequence_parallel_enabled=sequence_parallel,
+            no_async_tensor_model_parallel_allreduce=no_async_tensor_model_parallel_allreduce,
+            gradient_accumulation_fusion=gradient_accumulation_fusion,
+            transfer_with_static_ring=transfer_with_static_ring
+        )
+        self.key_value = get_linear_layer(
+            hidden_size,
+            2 * kv_channels,
+            init_method=init_method)
+        t1 = datetime.datetime.now()
+        logging.trace(
+            f"In ParallelAttention create self.query_key_value Begin: {t0} Elapsed: {(t1 - t0).total_seconds()} s", trace_type="recovery_time")
+
+        self.core_attention = MultiQueryCoreAttention(
+            layer_number=self.layer_number,
+            num_attention_heads=num_attention_heads,
+            hidden_size=hidden_size,
+            attention_type=self.attention_type,
+            attn_mask_type=self.attn_mask_type,
+            precision=precision,
+            apply_query_key_layer_scaling=apply_query_key_layer_scaling,
+            kv_channels=kv_channels,
+            masked_softmax_fusion=masked_softmax_fusion,
+            attention_dropout=attention_dropout,
+            multi_query_attention=multi_query_attention,
+            sequence_parallel=sequence_parallel,
+            normalize_attention_scores=normalize_attention_scores,
+            position_embedding_type=self.position_embedding_type,
+            position_interpolation_factor=self.position_interpolation_factor,
+            max_position_embeddings=max_position_embeddings,
+            rotary_percentage=self.rotary_percentage,
+        )
+
+        # Output.
+        t0 = datetime.datetime.now()
+        self.dense = tensor_parallel.RowParallelLinear(
+            projection_size,
+            hidden_size,
+            input_is_parallel=True,
+            init_method=output_layer_init_method,
+            skip_bias_add=True,
+            use_cpu_initialization=use_cpu_initialization,
+            bias=bias,
+            sequence_parallel_enabled=sequence_parallel,
+            gradient_accumulation_fusion=gradient_accumulation_fusion,
+            transfer_with_static_ring=transfer_with_static_ring,
+        )
+        t1 = datetime.datetime.now()
+        logging.trace(
+            f"In ParallelAttention create self.dense Begin: {t0} Elapsed: {(t1 - t0).total_seconds()} s", trace_type="recovery_time")
+
+        self.headscale = headscale
+        if headscale:
+            self.head_scale_tensor = torch.nn.Parameter(
+                torch.ones(1, self.num_attention_heads_per_partition, 1, 1), requires_grad=True
+            )
+
+        # Inference key-value memory
+        self.inference_key_memory = None
+        self.inference_value_memory = None
+        self.inference_current_sequence_len = 0
+
+        # relative position embedding
+        self.layer_type = layer_type
+
+    def _checkpointed_attention_forward(
+        self,
+        query_layer,
+        key_layer,
+        value_layer,
+        attention_mask,
+        rotary_pos_emb=None,
+        relative_position_bias=None,
+        headscale_tensor=None,
+    ):
+        """Forward method with activation checkpointing."""
+
+        def custom_forward(*inputs):
+            if len(inputs) == 7:
+                query_layer = inputs[0]
+                key_layer = inputs[1]
+                value_layer = inputs[2]
+                attention_mask = inputs[3]
+                rotary_pos_emb = inputs[4]
+                relative_position_bias = inputs[5]
+                headscale_tensor = inputs[6]
+            elif len(inputs) == 8:
+                query_layer = inputs[0]
+                key_layer = inputs[1]
+                value_layer = inputs[2]
+                attention_mask = inputs[3]
+                rotary_pos_emb = (inputs[4], inputs[5])
+                relative_position_bias = inputs[6]
+                headscale_tensor = inputs[7]
+            else:
+                raise ValueError('unexpected number of inputs')
+            output_ = self.core_attention(
+                query_layer,
+                key_layer,
+                value_layer,
+                attention_mask,
+                rotary_pos_emb=rotary_pos_emb,
+                relative_position_bias=relative_position_bias,
+                headscale_tensor=headscale_tensor,
+            )
+            return output_
+
+        if rotary_pos_emb is None:
+            rot_tuple = (rotary_pos_emb,)
+        else:
+            rot_tuple = (rotary_pos_emb[0], rotary_pos_emb[1])
+
+        hidden_states = tensor_parallel.checkpoint(
+            custom_forward,
+            False,
+            query_layer,
+            key_layer,
+            value_layer,
+            attention_mask,
+            *rot_tuple,
+            relative_position_bias,
+            headscale_tensor,
+        )
+
+        return hidden_states
+
+    def _allocate_memory(self, inference_max_sequence_len, batch_size, dtype):
+        return torch.empty(
+            inference_max_sequence_len,
+            batch_size,
+            self.num_attention_heads_per_partition,
+            self.hidden_size_per_attention_head,
+            dtype=dtype,
+            device=torch.cuda.current_device(),
+        )
+
+    def _transpose_last_dim(self, mixed_layer, num_splits, num_splits_first):
+        input_shape = mixed_layer.size()
+        if num_splits_first:
+            """[s, b, num_splits * np * hn]
+            -->(view) [s, b, num_splits, np, hn]
+            -->(tranpose) [s, b, np, num_splits, hn]
+            -->(view) [s, b, np * num_splits * hn] """
+
+            intermediate_shape = input_shape[:-1] + (
+                num_splits,
+                self.num_attention_heads_per_partition,
+                self.hidden_size_per_attention_head,
+            )
+
+            mixed_layer = mixed_layer.view(*intermediate_shape)
+            mixed_layer = mixed_layer.transpose(-2, -3).contiguous()
+        else:
+            """[s, b, np * hn * num_splits]
+            -->(view) [s, b, np, hn, num_splits]
+            -->(tranpose) [s, b, np, num_splits, hn]
+            -->(view) [s, b, np * num_splits * hn] """
+
+            intermediate_shape = input_shape[:-1] + (
+                self.num_attention_heads_per_partition,
+                self.hidden_size_per_attention_head,
+                num_splits,
+            )
+
+            mixed_layer = mixed_layer.view(*intermediate_shape)
+            mixed_layer = mixed_layer.transpose(-1, -2).contiguous()
+        mixed_layer = mixed_layer.view(*input_shape)
+
+        return mixed_layer
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask,
+        layer_past=None,
+        get_key_value=False,
+        encoder_output=None,
+        set_inference_key_value_memory=False,
+        inference_max_sequence_len=None,
+        rotary_pos_emb=None,  # rotary positional embedding
+        relative_position_bias=None,
+        checkpoint_core_attention=False,
+    ):
+        # hidden_states: [sq, b, h]
+
+        # =================================================
+        # Pre-allocate memory for key-values for inference.
+        # =================================================
+        if set_inference_key_value_memory:
+            assert inference_max_sequence_len and inference_max_sequence_len > 0
+            self.inference_key_memory = self._allocate_memory(
+                inference_max_sequence_len, hidden_states.size(
+                    1), hidden_states.dtype
+            )
+            self.inference_value_memory = self._allocate_memory(
+                inference_max_sequence_len, hidden_states.size(
+                    1), hidden_states.dtype
+            )
+            self.inference_current_sequence_len = 0
+
+        # Some consistency check.
+        if inference_max_sequence_len:
+            assert self.inference_current_sequence_len < self.inference_key_memory.size(
+                0)
+            assert inference_max_sequence_len == self.inference_key_memory.size(
+                0)
+        # This is added for safety. In case inference_max_sequence_len
+        # is not provided, make sure there is no potential memory left
+        # from previous inference.
+        if not inference_max_sequence_len:
+            self.inference_key_memory = None
+            self.inference_value_memory = None
+
+        # =====================
+        # Query, Key, and Value
+        # =====================
+
+        if self.attention_type == AttnType.self_attn:
+            # Attention heads [sq, b, h] --> [sq, b, (np * 3 * hn)]
+            # mixed_x_layer, _ = self.query_key_value(hidden_states)
+
+            # [sq, b, (np * 3 * hn)] --> [sq, b, np, 3 * hn]
+            # new_tensor_shape = mixed_x_layer.size()[:-1] + (
+            #    self.num_attention_heads_per_partition,
+            #    3 * self.hidden_size_per_attention_head,
+            # )
+            # if self.megatron_legacy:
+            #    mixed_x_layer = self._transpose_last_dim(mixed_x_layer, 3, True)
+            # mixed_x_layer = mixed_x_layer.view(*new_tensor_shape)
+
+            # [sq, b, np, 3 * hn] --> 3 [sq, b, np, hn]
+            # (query_layer, key_layer, value_layer) = tensor_parallel.split_tensor_along_last_dim(mixed_x_layer, 3)
+            #            kv_input=hidden_states
+            # Attention heads [sq, b, h] --> [sq, b, (2 * hn)]
+            kv_input = hidden_states
+            mixed_kv_layer = self.key_value(kv_input)
+
+            # Reduce the KV gradients in the tensor-parallel direction.
+            # This is different from multi-head attention which reduces the KV input,
+            # because the sum over attn heads happens in the attn weight gradient instead of the KV layer:
+            #   A [b, n * sq, sk] = Q [b, n * sq, hn] x K^T [b, hn, sk]
+            #   G_K [b, sk, hn] = G_A [b, sk, n * sq] x Q [b, n * sq, hn]
+            #                   = sum_p (G_Ap [b, sk, np * sq] x Q_p [b, np * sq, hn])
+            if self.sequence_parallel:
+                # We switch to the tensor parallel regime here instead of at the KV input
+                # so that the KV layer is done in parallel instead of just duplicated.
+                mixed_kv_layer = tensor_parallel.mappings.gather_from_sequence_parallel_region(
+                    mixed_kv_layer)
+            else:
+                mixed_kv_layer = tensor_parallel.copy_to_tensor_model_parallel_region(
+                    mixed_kv_layer)
+            # [sq, b, (2 * hn)] --> [sq, b, np (expanded), 2 * hn]
+            # new_tensor_shape = mixed_kv_layer.size()[:-1] + \
+            #     (self.num_attention_heads_per_partition,
+            #      2 * self.hidden_size_per_attention_head)
+            # mixed_kv_layer = mixed_kv_layer.unsqueeze(2).expand(*new_tensor_shape)
+
+            # [sq, b, (2 * hn)] --> [sq, b, 1, 2 * hn]
+            new_tensor_shape = mixed_kv_layer.size()[:-1] + \
+                (1,
+                 2 * self.hidden_size_per_attention_head)
+            mixed_kv_layer = mixed_kv_layer.view(*new_tensor_shape)
+            # [sq, b, np, 2 * hn] --> 2 [sq, b, np, hn]
+            (key_layer,
+             value_layer) = tensor_parallel.split_tensor_along_last_dim(mixed_kv_layer, 2)
+            # Attention head [sq, b, h] --> [sq, b, np * hn]
+            query_layer, _ = self.query(hidden_states)
+            # [sq, b, np * hn] --> [sq, b, np, hn]
+            new_tensor_shape = query_layer.size()[:-1] + \
+                (self.num_attention_heads_per_partition,
+                 self.hidden_size_per_attention_head)
+            query_layer = query_layer.view(*new_tensor_shape)
+            # [sq, b, np, hn] -> [b, np * sq, hn]
+        else:
+            # Attention heads [sk, b, h] --> [sk, b, (np * 2 * hn)]
+            mixed_kv_layer, _ = self.key_value(encoder_output)
+
+            # [sk, b, (np * 2 * hn)] --> [sk, b, np, 2 * hn]
+            new_tensor_shape = mixed_kv_layer.size()[:-1] + (
+                self.num_attention_heads_per_partition,
+                2 * self.hidden_size_per_attention_head,
+            )
+            if self.megatron_legacy:
+                mixed_kv_layer = self._transpose_last_dim(
+                    mixed_kv_layer, 2, True)
+            mixed_kv_layer = mixed_kv_layer.view(*new_tensor_shape)
+
+            # [sk, b, np, 2 * hn] --> 2 [sk, b, np, hn]
+            (key_layer, value_layer) = tensor_parallel.split_tensor_along_last_dim(
+                mixed_kv_layer, 2)
+
+            # Attention head [sq, b, h] --> [sq, b, hp]
+            query_layer, _ = self.query(hidden_states)
+            # [sq, b, hp] --> [sq, b, np, hn]
+            new_tensor_shape = query_layer.size()[:-1] + (
+                self.num_attention_heads_per_partition,
+                self.hidden_size_per_attention_head,
+            )
+            query_layer = query_layer.view(*new_tensor_shape)
+
+        if self.is_adapter_available():
+            key_infused_adapter = self.get_from_adapter_layer(
+                AdapterName.KEY_INFUSED)
+            value_infused_adapter = self.get_from_adapter_layer(
+                AdapterName.VALUE_INFUSED)
+            if key_infused_adapter:
+                assert value_infused_adapter is not None, "Expected value_infused_adapter not found!"
+                kls = key_layer.shape
+                key_layer = key_infused_adapter(
+                    key_layer.reshape(kls[0], kls[1], -1)).reshape(kls)
+            if value_infused_adapter:
+                assert key_infused_adapter is not None, "Expected key_infused_adapter not found!"
+                vls = value_layer.shape
+                value_layer = value_infused_adapter(
+                    value_layer.reshape(vls[0], vls[1], -1)).reshape(vls)
+
+        # ===================================================
+        # Adjust key, value, and attention mask for inference
+        # ===================================================
+
+        # duplicate the pos_emb for self attention
+        if rotary_pos_emb is not None:
+            rotary_pos_emb = rotary_pos_emb if isinstance(
+                rotary_pos_emb, tuple) else ((rotary_pos_emb,) * 2)
+
+        if inference_max_sequence_len:
+            # Adjust the range variables.
+            start = self.inference_current_sequence_len
+            self.inference_current_sequence_len += key_layer.size(0)
+            end = self.inference_current_sequence_len
+            # Copy key and values.
+            self.inference_key_memory[start:end, ...] = key_layer
+            self.inference_value_memory[start:end, ...] = value_layer
+            key_layer = self.inference_key_memory[:end, ...]
+            value_layer = self.inference_value_memory[:end, ...]
+            # Adjust attention mask
+            attention_mask = attention_mask[..., start:end, :end]
+            # adjust the key rotary positional embedding
+            if rotary_pos_emb is not None:
+                q_pos_emb, k_pos_emb = rotary_pos_emb
+                if not set_inference_key_value_memory:
+                    # In inference, we compute one token at a time.
+                    # Select the correct positional embedding.
+                    q_pos_emb = q_pos_emb[end - 1: end]
+                else:
+                    q_pos_emb = q_pos_emb[:end, :, :, :]
+                k_pos_emb = k_pos_emb[:end, :, :, :]
+                rotary_pos_emb = (q_pos_emb, k_pos_emb)
+
+        if layer_past is not None:
+            past_key, past_value = layer_past
+            key_layer = torch.cat(
+                (past_key.type_as(key_layer), key_layer), dim=0)
+            value_layer = torch.cat(
+                (past_value.type_as(value_layer), value_layer), dim=0)
+
+        if get_key_value:
+            present = (key_layer, value_layer)
+
+        if checkpoint_core_attention:
+            context_layer = self._checkpointed_attention_forward(
+                query_layer,
+                key_layer,
+                value_layer,
+                attention_mask,
+                rotary_pos_emb=rotary_pos_emb,
+                relative_position_bias=relative_position_bias,
+                headscale_tensor=self.head_scale_tensor if self.headscale else None,
+            )
+        else:
+            context_layer = self.core_attention(
+                query_layer,
+                key_layer,
+                value_layer,
+                attention_mask,
+                layer_past=layer_past,
+                get_key_value=get_key_value,
+                rotary_pos_emb=rotary_pos_emb,
+                relative_position_bias=relative_position_bias,
+                headscale_tensor=self.head_scale_tensor if self.headscale else None,
+            )
+
+        # =================
+        # Output. [sq, b, h]
+        # =================
+        output, bias = self.dense(context_layer)
+
+        if get_key_value:
+            output = [output, present]
+
+        return output, bias
+
+
+class ParallelTransformerLayer_(MegatronModule, adapter_mixins.AdapterModuleMixin):
+    """A single transformer layer.
+
+    Transformer layer takes input with size [s, b, h] and returns an
+    output of the same size.
+    """
+
+    def __init__(
+        self,
+        init_method,
+        output_layer_init_method,
+        layer_number,
+        hidden_size,
+        ffn_hidden_size,
+        num_attention_heads,
+        layer_type=LayerType.encoder,
+        self_attn_mask_type=AttnMaskType.padding,
+        fp32_residual_connection=False,
+        precision=16,
+        apply_query_key_layer_scaling=True,
+        kv_channels=None,
+        layernorm_epsilon=1e-5,
+        hidden_dropout=0.1,
+        persist_layer_norm=False,
+        use_cpu_initialization=False,
+        bias_activation_fusion=True,
+        bias_dropout_add_fusion=True,
+        masked_softmax_fusion=True,
+        gradient_accumulation_fusion=False,
+        openai_gelu=False,
+        onnx_safe=False,
+        attention_dropout=0.1,
+        ffn_dropout=0.0,
+        activation='gelu',
+        megatron_legacy=False,
+        bias=True,
+        chunk_size=64,
+        normalization='layernorm',
+        transformer_block_type='pre_ln',
+        position_embedding_type='learned_absolute',
+        multi_query_attention=False,
+        headscale=False,
+        activations_checkpoint_granularity=None,
+        sequence_parallel=False,
+        normalize_attention_scores=True,
+        num_moe_experts=1,
+        moe_frequency=1,
+        moe_dropout=0.0,
+        position_interpolation_factor=1.0,
+        max_position_embeddings=4096,
+        rotary_percentage=1.0,
+    ):
+        super(ParallelTransformerLayer_, self).__init__()
+
+        if kv_channels is None:
+            assert (
+                hidden_size % num_attention_heads == 0
+            ), 'hidden_size must be divisible by num_attention_heads if kv_channels is None'
+            kv_channels = hidden_size // num_attention_heads
+
+        self.layer_number = layer_number
+        self.layer_type = layer_type
+        self.sequence_parallel = sequence_parallel
+        self.bias = bias
+        self.transformer_block_type = transformer_block_type
+        self.position_embedding_type = position_embedding_type
+        self.position_interpolation_factor = position_interpolation_factor
+        self.rotary_percentage = rotary_percentage
+        self.set_accepted_adapter_types(
+            [LinearAdapterConfig._target_, ParallelLinearAdapterConfig._target_])
+
+        if not bias and bias_dropout_add_fusion:
+            raise ValueError(
+                'bias_dropout_add_fusion=True requires bias=True, found bias=False. Either set both to True or both to False.'
+            )
+
+        if normalization not in ['layernorm', 'layernorm1p', 'rmsnorm']:
+            raise ValueError(
+                f'normalization must be "layernorm", "layernorm1p" or "rmsnorm", found {normalization}')
+
+        if transformer_block_type not in ['pre_ln', 'post_ln', 'normformer', 'gpt_j']:
+            raise ValueError(
+                f'transformer_block_type must be either "pre_ln" or "post_ln" or "normformer" or "gpt_j", found {transformer_block_type}'
+            )
+
+        # if true move residual connections to fp32
+        self.fp32_residual_connection = fp32_residual_connection
+        self.hidden_dropout = hidden_dropout
+        self.attention_dropout = attention_dropout
+        # if true, enable bias dropout fusion
+        self.bias_dropout_add_fusion = bias_dropout_add_fusion
+
+        self.checkpoint_layer_norm = (
+            activations_checkpoint_granularity == 'selective'
+        )  # transformer engine forward allows for more granular selective checkpointing
+        # For now do not transfer with static ring
+        transfer_with_static_ring = not self.checkpoint_layer_norm
+        # when selective enabled to avoid memory pressure
+
+        # Self attention.
+        # retrieval_decoder_after_self_attn skips the self attention
+        if self.layer_type != LayerType.retrieval_decoder_after_self_attn:
+            # Layernorm on the input data.
+            if normalization == 'layernorm':
+                self.input_layernorm = get_layer_norm(
+                    hidden_size, layernorm_epsilon, persist_layer_norm, sequence_parallel
+                )
+            elif normalization == 'layernorm1p':
+                self.input_layernorm = LayerNorm1P(
+                    hidden_size, layernorm_epsilon, sequence_parallel_enabled=sequence_parallel
+                )
+            else:
+                self.input_layernorm = MixedFusedRMSNorm(hidden_size, layernorm_epsilon,
+                                                         sequence_parallel_enabled=sequence_parallel)
+
+            logging.trace(
+                "In ParallelTransfomerLayer() create ParallelAttention for encoder ....", trace_type="recovery_time")
+            self.self_attention = ParallelAttention(
+                init_method=init_method,
+                output_layer_init_method=output_layer_init_method,
+                layer_number=layer_number,
+                num_attention_heads=num_attention_heads,
+                hidden_size=hidden_size,
+                attention_type=AttnType.self_attn,
+                attn_mask_type=self_attn_mask_type,
+                precision=precision,
+                apply_query_key_layer_scaling=apply_query_key_layer_scaling,
+                kv_channels=kv_channels,
+                use_cpu_initialization=use_cpu_initialization,
+                masked_softmax_fusion=masked_softmax_fusion,
+                attention_dropout=attention_dropout,
+                multi_query_attention=multi_query_attention,
+                layer_type=layer_type,
+                megatron_legacy=megatron_legacy,
+                bias=bias,
+                headscale=headscale,
+                activations_checkpoint_granularity=activations_checkpoint_granularity,
+                position_embedding_type=position_embedding_type,
+                sequence_parallel=sequence_parallel,
+                gradient_accumulation_fusion=gradient_accumulation_fusion,
+                normalize_attention_scores=normalize_attention_scores,
+                transfer_with_static_ring=transfer_with_static_ring,
+                position_interpolation_factor=position_interpolation_factor,
+                max_position_embeddings=max_position_embeddings,
+                rotary_percentage=self.rotary_percentage,
+            )
+            logging.trace(
+                "In ParallelTransfomerLayer() create ParallelAttention for encoder done", trace_type="recovery_time")
+
+            if transformer_block_type == 'normformer':
+                if normalization == 'layernorm':
+                    self.post_attention_normformer_norm = get_layer_norm(
+                        hidden_size, layernorm_epsilon, persist_layer_norm
+                    )
+                else:
+                    self.post_attention_normformer_norm = MixedFusedRMSNorm(hidden_size, layernorm_epsilon,
+                                                                            sequence_parallel_enabled=sequence_parallel)
+
+            if self.layer_type != LayerType.decoder_pre_mlp or self.transformer_block_type != 'post_ln':
+                #  the post_attention_layernorm is used for layermorm after mlp
+                # don't need it for decoder_pre_mlp and post_ln
+                if normalization == 'layernorm':
+                    self.post_attention_layernorm = get_layer_norm(
+                        hidden_size, layernorm_epsilon, persist_layer_norm, sequence_parallel
+                    )
+                elif normalization == 'layernorm1p':
+                    self.post_attention_layernorm = LayerNorm1P(
+                        hidden_size, layernorm_epsilon, sequence_parallel_enabled=sequence_parallel
+                    )
+                else:
+                    self.post_attention_layernorm = MixedFusedRMSNorm(hidden_size, layernorm_epsilon,
+                                                                      sequence_parallel_enabled=sequence_parallel)
+
+        if self.layer_type == LayerType.decoder_pre_mlp:
+            # skip MLP and cross attention
+            return
+
+        # the post_attention_layernorm is used for layermorm after mlp
+        # need it for post_ln
+        if self.layer_type == LayerType.retrieval_decoder_after_self_attn and self.transformer_block_type == 'post_ln':
+            # Layernorm on the attention output
+            if normalization == 'layernorm':
+                self.post_attention_layernorm = get_layer_norm(
+                    hidden_size, layernorm_epsilon, persist_layer_norm, sequence_parallel
+                )
+            elif normalization == 'layernorm1p':
+                self.post_attention_layernorm = LayerNorm1P(
+                    hidden_size, layernorm_epsilon, sequence_parallel_enabled=sequence_parallel
+                )
+            else:
+                self.post_attention_layernorm = MixedFusedRMSNorm(hidden_size, layernorm_epsilon,
+                                                                  sequence_parallel_enabled=sequence_parallel)
+
+        if self.layer_type in [LayerType.decoder,  LayerType.retrieval_encoder, LayerType.retrieval_decoder, LayerType.retrieval_decoder_after_self_attn]:
+            raise ValueError(f'Layer {self.layer_type} not supported')
+
+        # MLP
+        if num_moe_experts > 1 and self.layer_number % moe_frequency == 0:
+            logging.trace(
+                "In ParallelTransfomerLayer() create SwitchMLP ....", trace_type="recovery_time")
+            self.mlp = SwitchMLP(
+                num_experts=num_moe_experts,
+                init_method=init_method,
+                output_layer_init_method=output_layer_init_method,
+                hidden_size=hidden_size,
+                ffn_hidden_size=ffn_hidden_size,
+                use_cpu_initialization=use_cpu_initialization,
+                bias_activation_fusion=bias_activation_fusion,
+                openai_gelu=openai_gelu,
+                onnx_safe=onnx_safe,
+                activation=activation,
+                bias=bias,
+                transformer_block_type=transformer_block_type,
+                normalization=normalization,
+                layernorm_epsilon=layernorm_epsilon,
+                persist_layer_norm=persist_layer_norm,
+                sequence_parallel=sequence_parallel,
+                gradient_accumulation_fusion=gradient_accumulation_fusion,
+                dropout=moe_dropout,
+            )
+            logging.trace(
+                "In ParallelTransfomerLayer() create SwitchMLP ....", trace_type="recovery_time")
+        else:
+            logging.trace(
+                "In ParallelTransfomerLayer() create ParallelMLP ....", trace_type="recovery_time")
+            self.mlp = ParallelMLP(
+                init_method=init_method,
+                output_layer_init_method=output_layer_init_method,
+                hidden_size=hidden_size,
+                ffn_hidden_size=ffn_hidden_size,
+                use_cpu_initialization=use_cpu_initialization,
+                bias_activation_fusion=bias_activation_fusion,
+                openai_gelu=openai_gelu,
+                onnx_safe=onnx_safe,
+                activation=activation,
+                bias=bias,
+                transformer_block_type=transformer_block_type,
+                normalization=normalization,
+                layernorm_epsilon=layernorm_epsilon,
+                persist_layer_norm=persist_layer_norm,
+                sequence_parallel=sequence_parallel,
+                gradient_accumulation_fusion=gradient_accumulation_fusion,
+                dropout=ffn_dropout,
+                transfer_with_static_ring=transfer_with_static_ring,
+            )
+            logging.trace(
+                "In ParallelTransfomerLayer() create ParallelMLP done", trace_type="recovery_time")
+
+    def _get_bias_droput_add_func(self, transformer_block_type='pre_ln', position_after='attention'):
+        """
+        Returns a function that potentially fuses the dropout and bias addition.
+
+        This function is particularly helpful for the normformer architecture that does not the fused kernel after attention layers, but can after the MLP.
+        """
+        # Normformer activations at this point have no bias vector since they've gone through another normalization layer.
+        if transformer_block_type == 'normformer' and position_after == 'attention':
+            bias_dropout_add_func = get_dropout_add(self.training)
+        # Bias dropout add fused kernel
+        elif self.bias and self.bias_dropout_add_fusion:
+            if self.training:
+                bias_dropout_add_func = bias_dropout_add_fused_train
+            else:
+                bias_dropout_add_func = bias_dropout_add_fused_inference
+        # Bias dropout add non-fused kernel
+        elif self.bias and not self.bias_dropout_add_fusion:
+            bias_dropout_add_func = get_bias_dropout_add(self.training)
+        # Dropout add non-fused kernel for a model without bias terms.
+        else:
+            bias_dropout_add_func = get_dropout_add(self.training)
+
+        return bias_dropout_add_func
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask,
+        encoder_output=None,
+        enc_dec_attn_mask=None,
+        layer_past=None,
+        get_key_value=False,
+        set_inference_key_value_memory=False,
+        inference_max_sequence_len=None,
+        # list of positional embedding tensors, first one self attention, second one and third one are for cross attention (q, k)
+        rotary_pos_emb=None,
+        self_attention_relative_position_bias=None,
+        cross_attention_relative_position_bias=None,
+        checkpoint_core_attention=False,
+    ):
+        # Self attention.
+        if rotary_pos_emb is not None:
+            # self attention pos_emb is (q, q)
+            self_attention_pos_emb = (rotary_pos_emb[0], rotary_pos_emb[0])
+            cross_attention_pos_emb = (rotary_pos_emb[1], rotary_pos_emb[2])
+        else:
+            self_attention_pos_emb = None
+            cross_attention_pos_emb = None
+
+        if self.layer_type != LayerType.retrieval_decoder_after_self_attn:
+            # hidden_states: [b, s, h]
+
+            # Pre-LN: x -> LN -> MHA -> Residual -> LN -> MLP -> Residual
+            # Post-LN: x -> MHA -> Residual -> LN -> MLP -> Residual -> LN
+            # Normformer: x -> LN -> MHA -> LN -> Residual -> MLP (w/LN) -> Residual
+            # GPT_J: x -> LN -> MHA -> Residual -> + ->
+            #         x -> LN -> MLP      --        |
+            # See: https://github.com/EleutherAI/gpt-neox/blob/ac3d8087f1762213880523893a52329d66d2d1a9/megatron/model/transformer.py#L593
+
+            residual = hidden_states
+            # Layer norm at the beginning of the transformer layer.
+            if self.transformer_block_type in ['pre_ln', 'normformer']:
+                if self.checkpoint_layer_norm:
+                    hidden_states = tensor_parallel.checkpoint(
+                        self.input_layernorm, False, hidden_states)
+                else:
+                    hidden_states = self.input_layernorm(hidden_states)
+            elif self.transformer_block_type == 'gpt_j':
+                if self.checkpoint_layer_norm:
+                    normalization_output = tensor_parallel.checkpoint(
+                        self.post_attention_layernorm, False, hidden_states)
+                    hidden_states = tensor_parallel.checkpoint(
+                        self.input_layernorm, False, hidden_states)
+                else:
+                    normalization_output = self.post_attention_layernorm(
+                        hidden_states)
+                    hidden_states = self.input_layernorm(hidden_states)
+
+            # Materialize attention mask right before use
+            if is_torch_tpu_available():
+                seq_len = hidden_states.shape[0]  # See above [b, *s*, h] shape
+                if self.sequence_parallel:
+                    seq_len *= parallel_state.get_tensor_model_parallel_world_size()
+                attention_mask = torch.triu(torch.ones(
+                    (1, 1, seq_len, seq_len), device='xla'), diagonal=1).bool()
+
+            attention_output, attention_bias = self.self_attention(
+                hidden_states,
+                attention_mask,
+                layer_past=layer_past,
+                get_key_value=get_key_value,
+                set_inference_key_value_memory=set_inference_key_value_memory,
+                inference_max_sequence_len=inference_max_sequence_len,
+                rotary_pos_emb=self_attention_pos_emb,
+                relative_position_bias=self_attention_relative_position_bias,
+                checkpoint_core_attention=checkpoint_core_attention,
+            )
+
+            if get_key_value:
+                attention_output, presents = attention_output
+
+            # If normformer, apply norm on the output of the self attention.
+            if self.transformer_block_type == 'normformer':
+                # Normformer normalization
+                attention_output = (
+                    attention_output + attention_bias if attention_bias is not None else attention_output
+                )
+                attention_output = self.post_attention_normformer_norm(
+                    attention_output)
+                attention_bias = None
+
+            # jit scripting for a nn.module (with dropout) is not
+            # trigerring the fusion kernel. For now, we use two
+            # different nn.functional routines to account for varying
+            # dropout semantics during training and inference phases.
+
+            bias_dropout_add_func = self._get_bias_droput_add_func(
+                transformer_block_type=self.transformer_block_type, position_after='attention'
+            )
+            if attention_bias is not None:
+                attention_bias = attention_bias.expand_as(residual)
+
+            layernorm_input = bias_dropout_add_func(
+                attention_output, attention_bias, residual, self.hidden_dropout)
+            # print(f"Layer: {self.layer_number} Attention checksum {layernorm_input.sum()}")
+
+            if self.is_adapter_available():
+                adapter_1 = self.get_from_adapter_layer(
+                    AdapterName.PRE_ATTN_ADAPTER)
+                if adapter_1:
+                    strategy = adapter_1.adapter_strategy
+                    layernorm_input = self.forward_single_enabled_adapter_(
+                        layernorm_input,
+                        adapter_1,
+                        adapter_name=AdapterName.PRE_ATTN_ADAPTER,
+                        adapter_strategy=strategy,
+                    )
+
+            # Post-LN normalization after residual
+            if self.transformer_block_type == 'post_ln':
+                normalization_output = self.input_layernorm(layernorm_input)
+                layernorm_input = normalization_output
+            elif self.transformer_block_type in ['pre_ln', 'normformer']:
+                # Layer norm post the self attention.
+                if self.checkpoint_layer_norm:
+                    normalization_output = tensor_parallel.checkpoint(
+                        self.post_attention_layernorm, False, layernorm_input)
+                else:
+                    normalization_output = self.post_attention_layernorm(
+                        layernorm_input)
+            elif self.transformer_block_type == 'gpt_j':
+                pass  # handled above
+        else:
+            layernorm_input, normalization_output = hidden_states
+
+        if self.layer_type == LayerType.decoder_pre_mlp:
+            return layernorm_input, normalization_output
+
+        if (
+            self.layer_type == LayerType.decoder
+            or self.layer_type == LayerType.retrieval_decoder
+            or self.layer_type == LayerType.retrieval_encoder
+            or self.layer_type == LayerType.retrieval_decoder_after_self_attn
+        ):
+            if (
+                self.layer_type == LayerType.retrieval_decoder
+                or self.layer_type == LayerType.retrieval_decoder_after_self_attn
+            ):
+                attention_output, attention_bias = self.inter_attention(
+                    normalization_output,
+                    enc_dec_attn_mask,
+                    encoder_output=encoder_output,
+                    rotary_pos_emb=cross_attention_pos_emb,
+                    set_inference_key_value_memory=set_inference_key_value_memory,
+                    inference_max_sequence_len=inference_max_sequence_len,
+                    checkpoint_core_attention=checkpoint_core_attention,
+                )
+            else:
+
+                attention_output, attention_bias = self.inter_attention(
+                    normalization_output,
+                    enc_dec_attn_mask,
+                    encoder_output=encoder_output,
+                    rotary_pos_emb=cross_attention_pos_emb,
+                    relative_position_bias=cross_attention_relative_position_bias,
+                    checkpoint_core_attention=checkpoint_core_attention,
+                )
+
+            # If normformer, apply norm on the output of the self attention.
+            if self.transformer_block_type == 'normformer':
+                # Normformer normalization
+                attention_output = (
+                    attention_output + attention_bias if attention_bias is not None else attention_output
+                )
+                attention_output = self.post_inter_attention_normformer_norm(
+                    attention_output)
+                attention_bias = None
+
+            residual = layernorm_input
+
+            bias_dropout_add_func = self._get_bias_droput_add_func(
+                transformer_block_type=self.transformer_block_type, position_after='attention'
+            )
+
+            layernorm_input = bias_dropout_add_func(
+                attention_output, attention_bias, residual, self.hidden_dropout)
+            # print(f"Layer: {self.layer_number} Cross-Attention checksum {layernorm_input.sum()}")
+            normalization_output = self.post_inter_attention_layernorm(
+                layernorm_input)
+            # Post-LN normalization after residual
+            if self.transformer_block_type == 'post_ln':
+                layernorm_input = normalization_output
+        # MLP.
+        mlp_output, mlp_bias = self.mlp(normalization_output)
+
+        residual = layernorm_input
+
+        bias_dropout_add_func = self._get_bias_droput_add_func(
+            transformer_block_type=self.transformer_block_type, position_after='mlp'
+        )
+
+        output = bias_dropout_add_func(
+            mlp_output, mlp_bias, residual, self.hidden_dropout)
+        # print(f"Layer: {self.layer_number} MLP + Dropout + Residual checksum {output.sum()}")
+
+        if self.transformer_block_type == 'post_ln':
+            output = self.post_attention_layernorm(output)
+
+        if get_key_value:
+            output = [output, presents]
+
+        if (
+            self.is_adapter_available()
+        ):  # TODO: (@adithyre) was able to move adapter_2 back to the end of the transformer after ptl 1.7 update.
+            adapter_2 = self.get_from_adapter_layer(
+                AdapterName.POST_ATTN_ADAPTER)
+            if adapter_2:
+                strategy = adapter_2.adapter_strategy
+                output = self.forward_single_enabled_adapter_(
+                    output, adapter_2, adapter_name=AdapterName.POST_ATTN_ADAPTER, adapter_strategy=strategy
+                )
+
+        return output
+
+
+class ParallelTransformerLayer(ParallelTransformerLayer_):
+    def __init__(
+        self,
+        init_method,
+        output_layer_init_method,
+        layer_number,
+        hidden_size,
+        ffn_hidden_size,
+        num_attention_heads,
+        layer_type=LayerType.encoder,
+        self_attn_mask_type=AttnMaskType.padding,
+        fp32_residual_connection=False,
+        precision=16,
+        apply_query_key_layer_scaling=True,
+        kv_channels=None,
+        layernorm_epsilon=1e-5,
+        hidden_dropout=0.1,
+        bias_dropout_add_fusion=True,
+        persist_layer_norm=False,
+        use_cpu_initialization=False,
+        bias_activation_fusion=True,
+        openai_gelu=False,
+        onnx_safe=False,
+        masked_softmax_fusion=True,
+        attention_dropout=0.1,
+        ffn_dropout=0.0,
+        activation='gelu',
+        megatron_legacy=False,
+        bias=True,
+        chunk_size=64,
+        normalization='layernorm',
+        transformer_block_type='pre_ln',
+        position_embedding_type='learned_absolute',
+        multi_query_attention=False,
+        headscale=False,
+        activations_checkpoint_granularity=None,
+        sequence_parallel=False,
+        gradient_accumulation_fusion=False,
+        normalize_attention_scores=True,
+        num_moe_experts=1,
+        moe_frequency=1,
+        moe_dropout=0.0,
+        position_interpolation_factor=1.0,
+        max_position_embeddings=4096,
+        rotary_percentage=1.0,
+    ):
+        super(ParallelTransformerLayer, self).__init__(
+            init_method=init_method,
+            output_layer_init_method=output_layer_init_method,
+            layer_number=layer_number,
+            hidden_size=hidden_size,
+            ffn_hidden_size=ffn_hidden_size,
+            num_attention_heads=num_attention_heads,
+            layer_type=layer_type,
+            self_attn_mask_type=self_attn_mask_type,
+            fp32_residual_connection=fp32_residual_connection,
+            precision=precision,
+            apply_query_key_layer_scaling=apply_query_key_layer_scaling,
+            kv_channels=kv_channels,
+            layernorm_epsilon=layernorm_epsilon,
+            hidden_dropout=hidden_dropout,
+            bias_dropout_add_fusion=bias_dropout_add_fusion,
+            persist_layer_norm=persist_layer_norm,
+            use_cpu_initialization=use_cpu_initialization,
+            bias_activation_fusion=bias_activation_fusion,
+            openai_gelu=openai_gelu,
+            onnx_safe=onnx_safe,
+            masked_softmax_fusion=masked_softmax_fusion,
+            attention_dropout=attention_dropout,
+            ffn_dropout=ffn_dropout,
+            activation=activation,
+            megatron_legacy=megatron_legacy,
+            bias=bias,
+            chunk_size=chunk_size,
+            normalization=normalization,
+            transformer_block_type=transformer_block_type,
+            position_embedding_type=position_embedding_type,
+            headscale=headscale,
+            multi_query_attention=multi_query_attention,
+            activations_checkpoint_granularity=activations_checkpoint_granularity,
+            sequence_parallel=sequence_parallel,
+            gradient_accumulation_fusion=gradient_accumulation_fusion,
+            normalize_attention_scores=normalize_attention_scores,
+            num_moe_experts=num_moe_experts,
+            moe_frequency=moe_frequency,
+            moe_dropout=moe_dropout,
+            position_interpolation_factor=position_interpolation_factor,
+            max_position_embeddings=max_position_embeddings,
+            rotary_percentage=rotary_percentage,
+        )
+
+        if precision == 32:
+            self.dtype = torch.float32
+        elif precision == 16:
+            self.dtype = torch.float16
+        elif precision == 'bf16':
+            self.dtype = torch.bfloat16
+        else:
+            raise ValueError
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask,
+        encoder_output=None,
+        enc_dec_attn_mask=None,
+        rotary_pos_emb=None,
+        layer_past=None,
+        get_key_value=False,
+        set_inference_key_value_memory=False,
+        inference_max_sequence_len=None,
+        self_attention_relative_position_bias=None,
+        cross_attention_relative_position_bias=None,
+        checkpoint_core_attention=False,
+    ):
+        if self.dtype == torch.float32:
+            return super().forward(
+                hidden_states,
+                attention_mask,
+                encoder_output,
+                enc_dec_attn_mask,
+                layer_past,
+                get_key_value,
+                set_inference_key_value_memory,
+                inference_max_sequence_len,
+                rotary_pos_emb,
+                self_attention_relative_position_bias,
+                cross_attention_relative_position_bias,
+                checkpoint_core_attention,
+            )
+        with torch.autocast(device_type="cuda", dtype=self.dtype):
+            return super().forward(
+                hidden_states,
+                attention_mask,
+                encoder_output,
+                enc_dec_attn_mask,
+                layer_past,
+                get_key_value,
+                set_inference_key_value_memory,
+                inference_max_sequence_len,
+                rotary_pos_emb,
+                self_attention_relative_position_bias,
+                cross_attention_relative_position_bias,
+                checkpoint_core_attention,
+            )
+
+
+class AutocastTransformerLayer(TransformerLayer):
+    def __init__(
+        self,
+        hidden_size: int,
+        ffn_hidden_size: int,
+        layernorm_epsilon: float,
+        num_attention_heads: int,
+        init_method: Callable,
+        output_layer_init_method: Callable,
+        hidden_dropout: float,
+        attention_dropout: float,
+        layer_number: Optional[int] = None,
+        kv_channels: Optional[int] = None,
+        self_attn_mask_type: str = "causal",
+        tp_group: Optional[Any] = None,
+        tp_size: int = 1,
+        params_dtype: torch.dtype = torch.float32,
+        get_rng_state_tracker: Optional[Callable] = None,
+        fuse_wgrad_accumulation: bool = False,
+        apply_query_key_layer_scaling: bool = True,
+        attention_softmax_in_fp32: bool = False,
+        seq_length: Optional[int] = None,
+        micro_batch_size: Optional[int] = None,
+        sequence_parallel: bool = False,
+        apply_residual_connection_post_layernorm: bool = False,
+        output_layernorm: bool = False,
+        layer_type: str = "encoder",
+        drop_path_rate: float = 0,
+        use_emha: bool = False,
+        autocast_dtype: Any = 16,
+    ) -> None:
+        super().__init__(
+            hidden_size=hidden_size,
+            ffn_hidden_size=ffn_hidden_size,
+            layernorm_epsilon=layernorm_epsilon,
+            num_attention_heads=num_attention_heads,
+            init_method=init_method,
+            output_layer_init_method=output_layer_init_method,
+            hidden_dropout=hidden_dropout,
+            attention_dropout=attention_dropout,
+            layer_number=layer_number,
+            kv_channels=kv_channels,
+            self_attn_mask_type=self_attn_mask_type,
+            tp_group=tp_group,
+            tp_size=tp_size,
+            params_dtype=params_dtype,
+            get_rng_state_tracker=get_rng_state_tracker,
+            fuse_wgrad_accumulation=fuse_wgrad_accumulation,
+            apply_query_key_layer_scaling=apply_query_key_layer_scaling,
+            attention_softmax_in_fp32=attention_softmax_in_fp32,
+            seq_length=seq_length,
+            micro_batch_size=micro_batch_size,
+            sequence_parallel=sequence_parallel,
+            apply_residual_connection_post_layernorm=apply_residual_connection_post_layernorm,
+            output_layernorm=output_layernorm,
+            layer_type=layer_type,
+            drop_path_rate=drop_path_rate,
+            set_parallel_mode=tp_size > 1,
+            fuse_qkv_params=True,
+        )
+        # use_emha=use_emha,
+
+        if autocast_dtype == 32:
+            self.dtype = torch.float32
+        elif autocast_dtype == 16:
+            self.dtype = torch.float16
+        elif autocast_dtype == 'bf16':
+            self.dtype = torch.bfloat16
+        else:
+            raise ValueError
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        encoder_output: Optional[torch.Tensor] = None,
+        enc_dec_attn_mask: Optional[torch.Tensor] = None,
+        inference_params: Optional[Any] = None,
+        is_first_microbatch: Optional[bool] = None,
+        checkpoint_core_attention: Optional[bool] = False,
+    ) -> torch.Tensor:
+        if self.dtype == torch.float32:
+            return super().forward(
+                hidden_states,
+                attention_mask,
+                encoder_output=encoder_output,
+                enc_dec_attn_mask=enc_dec_attn_mask,
+                inference_params=inference_params,
+                is_first_microbatch=is_first_microbatch,
+                checkpoint_core_attention=checkpoint_core_attention,
+            )
+        with torch.autocast(device_type="cuda", dtype=self.dtype):
+            return super().forward(
+                hidden_states,
+                attention_mask,
+                encoder_output=encoder_output,
+                enc_dec_attn_mask=enc_dec_attn_mask,
+                inference_params=inference_params,
+                is_first_microbatch=is_first_microbatch,
+                checkpoint_core_attention=checkpoint_core_attention,
+            )
+
+
+class ParallelTransformer(MegatronModule):
+    """Transformer class."""
+
+    def __init__(
+        self,
+        init_method,
+        output_layer_init_method,
+        num_layers,
+        hidden_size,
+        ffn_hidden_size,
+        num_attention_heads,
+        apply_query_key_layer_scaling=True,
+        kv_channels=None,
+        layer_type=LayerType.encoder,  # it can be a list of types or single type
+        self_attn_mask_type=AttnMaskType.padding,
+        pre_process=True,
+        post_process=True,
+        precision=16,
+        fp32_residual_connection=False,
+        activations_checkpoint_method=None,
+        activations_checkpoint_num_layers=None,
+        layernorm_epsilon=1e-5,
+        hidden_dropout=0.1,
+        attention_dropout=0.1,
+        ffn_dropout=0.0,
+        use_cpu_initialization=False,
+        bias_activation_fusion=True,
+        bias_dropout_add_fusion=True,
+        masked_softmax_fusion=True,
+        gradient_accumulation_fusion=False,
+        persist_layer_norm=False,
+        openai_gelu=False,
+        onnx_safe=False,
+        activation='gelu',
+        model_type=ModelType.encoder_or_decoder,
+        megatron_legacy=False,
+        bias=True,
+        chunk_size=64,
+        normalization='layernorm',
+        transformer_block_type='pre_ln',
+        position_embedding_type='learned_absolute',
+        headscale=False,
+        layer_number_offset=0,  # this is use only for attention norm_factor scaling
+        activations_checkpoint_granularity=None,
+        activations_checkpoint_layers_per_pipeline=None,
+        sequence_parallel=False,
+        transformer_engine=False,
+        fp8=False,
+        fp8_e4m3=False,
+        fp8_hybrid=False,
+        fp8_margin=0,
+        fp8_interval=1,
+        fp8_amax_history_len=1,
+        fp8_amax_compute_algo='most_recent',
+        reduce_amax=True,
+        use_emha=False,
+        normalize_attention_scores=True,
+        multi_query_attention=False,
+        num_moe_experts=1,
+        moe_frequency=1,
+        moe_dropout=0.0,
+        position_interpolation_factor=1.0,
+        max_position_embeddings=4096,
+        rotary_percentage=1.0,
+    ):
+        super(ParallelTransformer, self).__init__()
+
+        if kv_channels is None:
+            assert (
+                hidden_size % num_attention_heads == 0
+            ), 'hidden_size must be divisible by num_attention_heads if kv_channels is None'
+            kv_channels = hidden_size // num_attention_heads
+
+        self.fp32_residual_connection = fp32_residual_connection
+        self.pre_process = pre_process
+        self.post_process = post_process
+        self.input_tensor = None
+        self.self_attn_mask_type = self_attn_mask_type
+        self.model_type = model_type
+        self.normalization = normalization
+        self.transformer_block_type = transformer_block_type
+        self.layer_type = layer_type
+        self.position_embedding_type = position_embedding_type
+        self.position_interpolation_factor = position_interpolation_factor
+        self.multi_query_attention = multi_query_attention
+        self.max_position_embeddings = max_position_embeddings
+        self.rotary_percentage = rotary_percentage
+        self.activations_checkpoint_method = activations_checkpoint_method
+        self.activations_checkpoint_num_layers = activations_checkpoint_num_layers
+        self.activations_checkpoint_granularity = activations_checkpoint_granularity
+        self.activations_checkpoint_layers_per_pipeline = activations_checkpoint_layers_per_pipeline
+
+        if self.activations_checkpoint_granularity:
+            if self.activations_checkpoint_granularity == 'selective':
+                if self.activations_checkpoint_method == 'uniform':
+                    logging.info(
+                        (
+                            f'Using uniform activation checkpointing with granularity selective forces all layers to use checkpointing.'
+                        )
+                    )
+                elif self.activations_checkpoint_method == 'block':
+                    logging.info(
+                        (
+                            f'Using block activation checkpointing requires activations_checkpoint_num_layers to be set.'
+                            f'Got: {self.activations_checkpoint_num_layers}. Setting to 1 by default.'
+                        )
+                    )
+                else:
+                    raise ValueError(
+                        f'activations_checkpoint_method should be "uniform" or "block" when using granularity selective.'
+                    )
+            elif self.activations_checkpoint_granularity == 'full':
+                if self.activations_checkpoint_method in ['uniform', 'block']:
+                    if not self.activations_checkpoint_num_layers:
+                        logging.info(
+                            (
+                                f'Using uniform or block activation checkpointing requires activations_checkpoint_num_layers to be set.'
+                                f'Got: {self.activations_checkpoint_num_layers}. Setting to 1 by default.'
+                            )
+                        )
+                else:
+                    raise ValueError(
+                        f'activations_checkpoint_method should be "uniform" or "block" when using granularity full.'
+                    )
+            else:
+                raise ValueError(
+                    f'activations_checkpoint_granularity should be "selective" or "full".')
+
+        self.sequence_parallel = sequence_parallel
+        self.transformer_engine = transformer_engine
+        self.fp8 = fp8
+        self.fp8_e4m3 = fp8_e4m3
+        self.fp8_hybrid = fp8_hybrid
+        self.fp8_margin = fp8_margin
+        self.fp8_interval = fp8_interval
+        self.fp8_amax_history_len = fp8_amax_history_len
+        self.fp8_amax_compute_algo = fp8_amax_compute_algo
+        self.reduce_amax = reduce_amax
+
+        self.fp8_recipe = None
+
+        if self.fp8:
+            if self.fp8_e4m3:
+                fp8_format = recipe.Format.E4M3
+            elif self.fp8_hybrid:
+                fp8_format = recipe.Format.HYBRID
+            self.fp8_recipe = recipe.DelayedScaling(
+                margin=self.fp8_margin,
+                interval=self.fp8_interval,
+                fp8_format=fp8_format,
+                amax_history_len=self.fp8_amax_history_len,
+                amax_compute_algo=self.fp8_amax_compute_algo,
+                reduce_amax=reduce_amax,
+            )
+
+        self.is_first_microbatch = True
+        # transformer engine forward needs to know if it is working on the first microbatch
+        self.microbatch_count = 0
+        self.checkpoint_core_attention = (
+            activations_checkpoint_granularity == 'selective'
+        )  # transformer engine forward allows for more granular selective checkpointing
+
+        if self.model_type == ModelType.encoder_or_decoder:
+            assert (
+                num_layers % parallel_state.get_pipeline_model_parallel_world_size() == 0
+            ), 'num_layers must be divisible by pipeline_model_parallel_size'
+
+        assert moe_frequency <= num_layers, 'MoE frequency must be <= number of transformer layers'
+        # TODO: Add similar assert for encoder-decoder.
+
+        self.num_layers = self.get_num_layers(num_layers)
+        # Transformer layers.
+
+        def build_layer(layer_number):
+            if isinstance(layer_type, list):
+                lt = layer_type[layer_number - 1]
+            else:
+                lt = layer_type
+
+            if self.transformer_engine:
+                logging.trace(
+                    f"building AutocastTransfomerLayer {layer_number} begin", trace_type="recovery_time")
+                return AutocastTransformerLayer(
+                    hidden_size=hidden_size,
+                    ffn_hidden_size=ffn_hidden_size,
+                    layernorm_epsilon=layernorm_epsilon,
+                    num_attention_heads=num_attention_heads,
+                    init_method=init_method,
+                    output_layer_init_method=output_layer_init_method,
+                    hidden_dropout=hidden_dropout,
+                    attention_dropout=attention_dropout,
+                    layer_number=layer_number + layer_number_offset,
+                    kv_channels=kv_channels,
+                    self_attn_mask_type=self_attn_mask_type.name,
+                    tp_size=parallel_state.get_tensor_model_parallel_world_size(),
+                    params_dtype=torch.float32,  # dtype params are initialized in
+                    get_rng_state_tracker=tensor_parallel.random.get_xla_rng_tracker,
+                    fuse_wgrad_accumulation=gradient_accumulation_fusion,
+                    apply_query_key_layer_scaling=apply_query_key_layer_scaling,
+                    seq_length=None,  # used for jit warmup
+                    micro_batch_size=None,  # used for jit warmup
+                    sequence_parallel=sequence_parallel,
+                    apply_residual_connection_post_layernorm=False,
+                    autocast_dtype=precision,
+                    use_emha=use_emha,
+                    zero_centered_gamma=normalization == 'layernorm1p',
+                )
+            else:
+                logging.trace(
+                    f"building ParallelTransformerLayer {layer_number} begin", trace_type="recovery_time")
+                return ParallelTransformerLayer(
+                    init_method=init_method,
+                    output_layer_init_method=output_layer_init_method,
+                    layer_number=layer_number + layer_number_offset,
+                    hidden_size=hidden_size,
+                    ffn_hidden_size=ffn_hidden_size,
+                    num_attention_heads=num_attention_heads,
+                    apply_query_key_layer_scaling=apply_query_key_layer_scaling,
+                    kv_channels=kv_channels,
+                    layer_type=lt,
+                    self_attn_mask_type=self_attn_mask_type,
+                    precision=precision,
+                    fp32_residual_connection=fp32_residual_connection,
+                    layernorm_epsilon=layernorm_epsilon,
+                    hidden_dropout=hidden_dropout,
+                    attention_dropout=attention_dropout,
+                    ffn_dropout=ffn_dropout,
+                    use_cpu_initialization=use_cpu_initialization,
+                    bias_activation_fusion=bias_activation_fusion,
+                    bias_dropout_add_fusion=bias_dropout_add_fusion,
+                    masked_softmax_fusion=masked_softmax_fusion,
+                    gradient_accumulation_fusion=gradient_accumulation_fusion,
+                    persist_layer_norm=persist_layer_norm,
+                    openai_gelu=openai_gelu,
+                    onnx_safe=onnx_safe,
+                    activation=activation,
+                    megatron_legacy=megatron_legacy,
+                    bias=bias,
+                    chunk_size=chunk_size,
+                    normalization=normalization,
+                    transformer_block_type=transformer_block_type,
+                    headscale=headscale,
+                    activations_checkpoint_granularity=activations_checkpoint_granularity,
+                    sequence_parallel=sequence_parallel,
+                    normalize_attention_scores=normalize_attention_scores,
+                    num_moe_experts=num_moe_experts,
+                    moe_frequency=moe_frequency,
+                    moe_dropout=moe_dropout,
+                    position_embedding_type=self.position_embedding_type,
+                    position_interpolation_factor=self.position_interpolation_factor,
+                    max_position_embeddings=self.max_position_embeddings,
+                    rotary_percentage=self.rotary_percentage,
+                    multi_query_attention=True
+                )
+
+        if parallel_state.get_virtual_pipeline_model_parallel_world_size() is not None:
+            assert num_layers % parallel_state.get_virtual_pipeline_model_parallel_world_size() == 0, (
+                'num_layers_per_stage must be divisible by ' 'virtual_pipeline_model_parallel_size'
+            )
+
+            assert self.model_type.value != 2, f'virtual pipeline parallel currently only supported for GPT'
+
+            # Number of layers in each model chunk is the number of layers in the stage,
+            # divided by the number of model chunks in a stage.
+            self.num_layers = self.num_layers // parallel_state.get_virtual_pipeline_model_parallel_world_size()
+            # With 8 layers, 2 stages, and 4 model chunks, we want an assignment of
+            # layers to stages like (each list is a model chunk):
+            # Stage 0: [0]  [2]  [4]  [6]
+            # Stage 1: [1]  [3]  [5]  [7]
+            # With 8 layers, 2 stages, and 2 virtual stages, we want an assignment of
+            # layers to stages like (each list is a model chunk):
+            # Stage 0: [0, 1]  [4, 5]
+            # Stage 1: [2, 3]  [6, 7]
+            offset = parallel_state.get_virtual_pipeline_model_parallel_rank() * (
+                num_layers // parallel_state.get_virtual_pipeline_model_parallel_world_size()
+            ) + (parallel_state.get_pipeline_model_parallel_rank() * self.num_layers)
+        else:
+            # Each stage gets a contiguous set of layers.
+            if (
+                self.model_type == ModelType.encoder_and_decoder
+                and parallel_state.get_pipeline_model_parallel_world_size() > 1
+            ):
+                pipeline_rank = parallel_state.get_pipeline_model_parallel_rank()
+                if layer_type == LayerType.encoder:
+                    offset = pipeline_rank * self.num_layers
+                else:
+                    num_ranks_in_enc = parallel_state.get_pipeline_model_parallel_split_rank()
+                    offset = (pipeline_rank - num_ranks_in_enc) * \
+                        self.num_layers
+            else:
+                offset = parallel_state.get_pipeline_model_parallel_rank() * self.num_layers
+
+        logging.trace(
+            "In ParallelTransformer(), building layers begin", trace_type="recovery_time")
+        self.layers = torch.nn.ModuleList(
+            [build_layer(i + 1 + offset) for i in range(self.num_layers)])
+        logging.trace("In ParallelTransformer(), building layers done",
+                      trace_type="recovery_time")
+
+        if self.post_process and self.transformer_block_type != 'post_ln':
+            # Final layer norm before output.
+            if normalization == 'layernorm':
+                self.final_layernorm = get_layer_norm(
+                    hidden_size, layernorm_epsilon, persist_layer_norm, sequence_parallel=sequence_parallel
+                )
+            elif normalization == 'layernorm1p':
+                self.final_layernorm = LayerNorm1P(
+                    hidden_size, layernorm_epsilon, sequence_parallel_enabled=sequence_parallel
+                )
+            else:
+                self.final_layernorm = MixedFusedRMSNorm(hidden_size, layernorm_epsilon,
+                                                         sequence_parallel_enabled=sequence_parallel)
+
+    def _get_layer(self, layer_number):
+        return self.layers[layer_number]
+
+    def get_num_layers(self, num_layers):
+        """Compute the number of transformer layers resident on the current rank."""
+        if parallel_state.get_pipeline_model_parallel_world_size() > 1:
+            if self.model_type == ModelType.encoder_and_decoder:
+                assert parallel_state.get_pipeline_model_parallel_split_rank() is not None
+                num_ranks_in_encoder = parallel_state.get_pipeline_model_parallel_split_rank()
+                num_ranks_in_decoder = parallel_state.get_pipeline_model_parallel_world_size() - \
+                    num_ranks_in_encoder
+                if self.layer_type == LayerType.encoder:
+                    assert (
+                        num_layers % num_ranks_in_encoder == 0
+                    ), 'num_layers must be divisible by number of ranks given to encoder'
+                elif self.layer_type == LayerType.decoder:
+                    assert (
+                        num_layers % num_ranks_in_decoder == 0
+                    ), 'num_layers must be divisible by number of ranks given to decoder'
+                else:
+                    raise ValueError(f"Unknown layer type {self.layer_type}")
+
+                if parallel_state.is_pipeline_stage_before_split():
+                    num_layers = num_layers // num_ranks_in_encoder
+                else:
+                    num_layers = num_layers // num_ranks_in_decoder
+            elif self.model_type == ModelType.encoder_or_decoder:
+                assert (
+                    num_layers % parallel_state.get_pipeline_model_parallel_world_size() == 0
+                ), 'num_layers must be divisible by pipeline_model_parallel_size'
+                num_layers = num_layers // parallel_state.get_pipeline_model_parallel_world_size()
+
+        return num_layers
+
+    def _checkpointed_forward(
+        self,
+        hidden_states,
+        attention_mask,
+        encoder_output,
+        enc_dec_attn_mask,
+        rotary_pos_emb,
+        self_attention_relative_position_bias,
+        cross_attention_relative_position_bias,
+        checkpoint_activations_all_layers,
+    ):
+        """Forward method with activation checkpointing."""
+
+        def custom(start, end):
+            if self.transformer_engine:
+
+                def custom_forward(*inputs):
+                    hidden_states = inputs[0]
+                    attention_mask = inputs[1]
+                    encoder_output = inputs[2]
+                    enc_dec_attn_mask = inputs[3]
+                    for index in range(start, end):
+                        layer = self._get_layer(index)
+                        hidden_states = layer(
+                            hidden_states,
+                            attention_mask,
+                            encoder_output=encoder_output,
+                            enc_dec_attn_mask=enc_dec_attn_mask,
+                            inference_params=None,
+                            is_first_microbatch=self.is_first_microbatch,
+                            checkpoint_core_attention=False,
+                        )
+
+                    return hidden_states
+
+            else:
+
+                def custom_forward(*inputs):
+                    if len(inputs) == 9:
+                        hidden_states = inputs[0]
+                        attention_mask = inputs[1]
+                        encoder_output = inputs[2]
+                        enc_dec_attn_mask = inputs[3]
+                        rotary_pos_emb = (inputs[4], inputs[5], inputs[6])
+                        self_attention_relative_position_bias = inputs[7]
+                        cross_attention_relative_position_bias = inputs[8]
+                    elif len(inputs) == 10:
+                        hidden_states = (inputs[0], inputs[1])
+                        attention_mask = inputs[2]
+                        encoder_output = inputs[3]
+                        enc_dec_attn_mask = inputs[4]
+                        rotary_pos_emb = (inputs[5], inputs[6], inputs[7])
+                        self_attention_relative_position_bias = inputs[8]
+                        cross_attention_relative_position_bias = inputs[9]
+                    else:
+                        hidden_states = inputs[0]
+                        attention_mask = inputs[1]
+                        encoder_output = inputs[2]
+                        enc_dec_attn_mask = inputs[3]
+                        rotary_pos_emb = inputs[4]
+                        self_attention_relative_position_bias = inputs[5]
+                        cross_attention_relative_position_bias = inputs[6]
+                    for index in range(start, end):
+                        layer = self._get_layer(index)
+                        hidden_states = layer(
+                            hidden_states=hidden_states,
+                            attention_mask=attention_mask,
+                            encoder_output=encoder_output,
+                            enc_dec_attn_mask=enc_dec_attn_mask,
+                            rotary_pos_emb=rotary_pos_emb,
+                            self_attention_relative_position_bias=self_attention_relative_position_bias,
+                            cross_attention_relative_position_bias=cross_attention_relative_position_bias,
+                        )
+                        if isinstance(hidden_states, tuple):
+                            pass
+                        else:
+                            hidden_states = hidden_states.contiguous()
+                    return hidden_states
+
+            return custom_forward
+
+        # Make sure memory is freed.
+        tensor_parallel.reset_checkpointed_activations_memory_buffer()
+
+        if self.activations_checkpoint_method == 'uniform':
+            # Uniformly divide the total number of Transformer layers and checkpoint
+            # the input activation of each divided chunk.
+            # A method to further reduce memory usage reducing checkpoints.
+            l = 0
+            while l < self.num_layers:
+                if isinstance(hidden_states, tuple):
+                    hidden_tuple = (hidden_states[0], hidden_states[1])
+                else:
+                    hidden_tuple = (hidden_states,)
+                middle_tuple = (
+                    attention_mask,
+                    encoder_output,
+                    enc_dec_attn_mask,
+                )
+
+                if rotary_pos_emb is None:
+                    rot_tuple = (rotary_pos_emb,)
+                else:
+                    rot_tuple = (
+                        rotary_pos_emb[0], rotary_pos_emb[1], rotary_pos_emb[2])
+
+                final_tuple = (self_attention_relative_position_bias,
+                               cross_attention_relative_position_bias)
+                arg_tuple = hidden_tuple + middle_tuple + rot_tuple + final_tuple
+
+                if self.transformer_engine:
+                    hidden_states = te_checkpoint(
+                        custom(l, l + self.activations_checkpoint_num_layers),
+                        False,
+                        tensor_parallel.random.get_xla_rng_tracker,
+                        parallel_state.get_tensor_model_parallel_group(),
+                        *arg_tuple,
+                    )
+                else:
+                    hidden_states = tensor_parallel.checkpoint(
+                        custom(
+                            l, l + self.activations_checkpoint_num_layers), False, *arg_tuple
+                    )
+                l += self.activations_checkpoint_num_layers
+        elif self.activations_checkpoint_method == 'block':
+            # When pipeline-parallel size > 1 and 'num_micro_batches_with_partial_activation_checkpoints' = int,
+            # pipeline scheduling can force to checkpoint all layers or partial layers in a micro-batch.
+            if checkpoint_activations_all_layers:
+                activations_checkpoint_num_layers = self.num_layers
+            else:
+                activations_checkpoint_num_layers = self.activations_checkpoint_num_layers
+                if (
+                    parallel_state.get_pipeline_model_parallel_world_size() > 0
+                    and self.activations_checkpoint_layers_per_pipeline is not None
+                ):
+                    # Decrease the number of layers to checkpoint at later pipeline stages
+                    activations_checkpoint_num_layers -= int(
+                        parallel_state.get_pipeline_model_parallel_rank()
+                        * self.activations_checkpoint_layers_per_pipeline
+                    )
+            # Checkpoint the input activation of only a set number of individual
+            # Transformer layers and skip the rest.
+            # A method fully use the device memory removing redundant re-computation.
+            for l in range(self.num_layers):
+                if isinstance(hidden_states, tuple):
+                    hidden_tuple = (hidden_states[0], hidden_states[1])
+                else:
+                    hidden_tuple = (hidden_states,)
+                middle_tuple = (
+                    attention_mask,
+                    encoder_output,
+                    enc_dec_attn_mask,
+                )
+
+                if rotary_pos_emb is None:
+                    rot_tuple = (rotary_pos_emb,)
+                else:
+                    rot_tuple = (
+                        rotary_pos_emb[0], rotary_pos_emb[1], rotary_pos_emb[2])
+
+                final_tuple = (self_attention_relative_position_bias,
+                               cross_attention_relative_position_bias)
+                arg_tuple = hidden_tuple + middle_tuple + rot_tuple + final_tuple
+
+                if l < activations_checkpoint_num_layers:
+                    if self.transformer_engine:
+                        hidden_states = te_checkpoint(
+                            custom(l, l + 1),
+                            False,
+                            tensor_parallel.random.get_xla_rng_tracker,
+                            parallel_state.get_tensor_model_parallel_group(),
+                            *arg_tuple,
+                        )
+                    else:
+                        hidden_states = tensor_parallel.checkpoint(
+                            custom(l, l + 1), False, *arg_tuple)
+                else:
+                    hidden_states = custom(l, l + 1)(*arg_tuple)
+        else:
+            raise ValueError("Invalid activation checkpoint method.")
+
+        return hidden_states
+
+    def set_input_tensor(self, input_tensor):
+        """Set input tensor to be used instead of forward()'s input.
+
+        When doing pipeline parallelism the input from the previous
+        stage comes from communication, not from the input, so the
+        model's forward_step_func won't have it. This function is thus
+        used by internal code to bypass the input provided by the
+        forward_step_func"""
+        self.input_tensor = input_tensor
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask,
+        layer_past=None,
+        get_key_value=False,
+        encoder_output=None,
+        enc_dec_attn_mask=None,
+        set_inference_key_value_memory=False,
+        inference_max_sequence_len=None,
+        # list of positional embedding tensors, first one self attention, second one and third one are for cross attention (q, k)
+        rotary_pos_emb=None,
+        # tensor of retrieved embedding of shape [b, k, r, n, d]
+        retrieved_emb=None,
+        self_attention_relative_position_bias=None,
+        cross_attention_relative_position_bias=None,
+        checkpoint_activations_all_layers=None,
+    ):
+        # Checks.
+        if inference_max_sequence_len:
+            assert self.activations_checkpoint_method is None, 'inference does not work with activation checkpointing'
+
+        if layer_past is not None:
+            assert get_key_value, 'for not None values in layer_past, ' 'expected get_key_value to be set'
+        if get_key_value:
+            assert self.activations_checkpoint_method is None, (
+                'get_key_value does not work with ' 'activation checkpointing'
+            )
+
+        if not self.pre_process:
+            # See set_input_tensor()
+            hidden_states = self.input_tensor
+
+        # TODO: @Yi Dong, what should this be?
+        if retrieved_emb is not None:
+            assert len(retrieved_emb.shape) == 5
+            # this is retrieval decoder, need special transpose
+            encoder_output = rearrange(
+                retrieved_emb, 'b k r n d -> k r n b d').contiguous()
+
+        """
+        is_first_microbatch is an optimization parameter for transformer engine.
+        It indicates if the current step in the forward pass is the first in a gradient accumulation cycle.
+        If set, FP8 weights are cached and some minor optimizations are applied to fuse_wgrad_accumulation
+        """
+        from apex.transformer.pipeline_parallel.utils import _GLOBAL_NUM_MICROBATCHES_CALCULATOR
+
+        num_micro_batches = getattr(
+            _GLOBAL_NUM_MICROBATCHES_CALCULATOR, 'num_micro_batches', 1)
+
+        if self.sequence_parallel:
+            rng_context = tensor_parallel.random.get_xla_rng_tracker().fork()
+        else:
+            rng_context = nullcontext()
+
+        with rng_context:
+            # fp8_autocast will not do anything if TE or FP8 isn't used
+            fp8_group = None
+            if parallel_state.model_parallel_is_initialized():
+                fp8_group = parallel_state.get_data_parallel_group()
+
+            if HAVE_TE:
+                # if TE is installed but fp8 is not available then this will do nothing
+                fp8_context = fp8_autocast(
+                    enabled=self.fp8, fp8_recipe=self.fp8_recipe, fp8_group=fp8_group)
+
+            else:
+                fp8_context = nullcontext()
+
+            with fp8_context:
+                if self.activations_checkpoint_granularity == 'full' and self.activations_checkpoint_num_layers > 0:
+                    hidden_states = self._checkpointed_forward(
+                        hidden_states,
+                        attention_mask,
+                        encoder_output,
+                        enc_dec_attn_mask,
+                        rotary_pos_emb,
+                        self_attention_relative_position_bias,
+                        cross_attention_relative_position_bias,
+                        checkpoint_activations_all_layers,
+                    )
+                else:
+                    if get_key_value:
+                        presents = []
+
+                    for index in range(self.num_layers):
+                        layer = self._get_layer(index)
+                        past = None
+
+                        if layer_past is not None:
+                            past = layer_past[index]
+
+                        if self.activations_checkpoint_granularity == 'selective':
+                            # When pipeline-parallel size > 1 and 'num_micro_batches_with_partial_activation_checkpoints' = int,
+                            # pipeline scheduling can force to checkpoint all layers or partial layers in a micro-batch.
+                            if (
+                                checkpoint_activations_all_layers == True
+                                or self.activations_checkpoint_method == 'uniform'
+                            ):
+                                checkpoint_core_attention = True
+                            elif self.activations_checkpoint_method == 'block':
+                                activations_checkpoint_num_layers = self.activations_checkpoint_num_layers
+                                # Decrease the number of layers to checkpoint at later pipeline stages
+                                if self.activations_checkpoint_layers_per_pipeline is not None:
+                                    activations_checkpoint_num_layers -= int(
+                                        parallel_state.get_pipeline_model_parallel_rank()
+                                        * self.activations_checkpoint_layers_per_pipeline
+                                    )
+                                checkpoint_core_attention = index < activations_checkpoint_num_layers
+                        else:
+                            checkpoint_core_attention = False
+
+                        if self.transformer_engine:
+
+                            inference_params = None
+
+                            hidden_states = layer(
+                                hidden_states,
+                                attention_mask,
+                                encoder_output=encoder_output,
+                                enc_dec_attn_mask=enc_dec_attn_mask,
+                                inference_params=inference_params,
+                                is_first_microbatch=self.is_first_microbatch,
+                                checkpoint_core_attention=checkpoint_core_attention,
+                            )
+
+                        else:
+                            hidden_states = layer(
+                                hidden_states,
+                                attention_mask,
+                                encoder_output=encoder_output,
+                                enc_dec_attn_mask=enc_dec_attn_mask,
+                                layer_past=past,
+                                get_key_value=get_key_value,
+                                set_inference_key_value_memory=set_inference_key_value_memory,
+                                inference_max_sequence_len=inference_max_sequence_len,
+                                rotary_pos_emb=rotary_pos_emb,
+                                self_attention_relative_position_bias=self_attention_relative_position_bias,
+                                cross_attention_relative_position_bias=cross_attention_relative_position_bias,
+                                checkpoint_core_attention=checkpoint_core_attention,
+                            )
+
+        # Skip counter update for eval and activation checkpointing
+        if torch.is_grad_enabled() and self.training:
+            self.microbatch_count += 1
+            if self.microbatch_count % num_micro_batches == 0:
+                self.microbatch_count = 0
+                self.is_first_microbatch = True
+            else:
+                self.is_first_microbatch = False
+
+        output = hidden_states
+
+        # Final layer norm.
+        if self.post_process:
+            # only apply the final_layernorm for pre-ln
+            if self.transformer_block_type != 'post_ln':
+                output = self.final_layernorm(hidden_states)
+
+        if get_key_value:
+            output = [output, presents]
+
+        return output
+
+
+class TransformerLanguageModel(MegatronModule):
+    """Transformer language model.
+
+    Arguments:
+        transformer_hparams: transformer hyperparameters
+        vocab_size: vocabulary size
+        max_sequence_length: maximum size of sequence. This
+                             is used for positional embedding
+        embedding_dropout_prob: dropout probability for embeddings
+        num_tokentypes: size of the token-type embeddings. 0 value
+                        will ignore this embedding
+    """
+
+    def __init__(
+        self,
+        init_method,
+        output_layer_init_method,
+        encoder_attn_mask_type,
+        vocab_size,
+        max_position_embeddings,
+        hidden_size,
+        ffn_hidden_size,
+        num_layers,
+        num_tokentypes,
+        num_attention_heads,
+        apply_query_key_layer_scaling=True,
+        kv_channels=None,
+        add_decoder=False,
+        decoder_attn_mask_type=AttnMaskType.causal,
+        add_pooler=False,
+        pre_process=True,
+        post_process=True,
+        use_cpu_initialization=False,
+        hidden_dropout=0.1,
+        attention_dropout=0.1,
+        ffn_dropout=0.0,
+        precision=16,
+        fp32_residual_connection=False,
+        activations_checkpoint_method=None,
+        activations_checkpoint_num_layers=1,
+        normalization='layernorm',
+        layernorm_epsilon=1e-5,
+        bias_activation_fusion=True,
+        bias_dropout_add_fusion=True,
+        bias=True,
+        masked_softmax_fusion=True,
+        activation='gelu',
+        headscale=False,
+        transformer_block_type='pre_ln',
+        normalize_attention_scores=True,
+        position_embedding_type='learned_absolute',
+        rotary_percentage=1.0,
+        share_embeddings_and_output_weights=True,
+        gradient_accumulation_fusion=False,
+        persist_layer_norm=False,
+        openai_gelu=False,
+        onnx_safe=False,
+        megatron_legacy=False,
+        activations_checkpoint_granularity=None,
+        activations_checkpoint_layers_per_pipeline=None,
+        sequence_parallel=False,
+        transformer_engine=False,
+        fp8=False,
+        fp8_e4m3=False,
+        fp8_hybrid=False,
+        fp8_margin=0,
+        fp8_interval=1,
+        fp8_amax_history_len=1,
+        fp8_amax_compute_algo='most_recent',
+        reduce_amax=True,
+        use_emha=False,
+        position_interpolation_factor=1.0,
+    ):
+        super(TransformerLanguageModel, self).__init__(
+            share_token_embeddings=share_embeddings_and_output_weights)
+
+        self.pre_process = pre_process
+        self.post_process = post_process
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+        self.vocab_size = vocab_size
+        self.max_position_embeddings = max_position_embeddings
+        self.num_tokentypes = num_tokentypes
+        self.init_method = init_method
+        self.encoder_attn_mask_type = encoder_attn_mask_type
+        self.add_decoder = add_decoder
+        self.decoder_attn_mask_type = decoder_attn_mask_type
+        self.add_pooler = add_pooler
+        self.hidden_dropout = hidden_dropout
+        self.output_layer_init_method = output_layer_init_method
+        self.position_embedding_type = position_embedding_type
+        self.position_interpolation_factor = position_interpolation_factor
+        self.share_embeddings_and_output_weights = share_embeddings_and_output_weights
+        self.sequence_parallel = sequence_parallel
+        self.rotary_percentage = rotary_percentage
+        assert 0 < rotary_percentage <= 1
+
+        if kv_channels is None:
+
+            assert (
+                hidden_size % num_attention_heads == 0
+            ), 'hidden_size must be divisible by num_attention_heads if kv_channels is None'
+            kv_channels = hidden_size // num_attention_heads
+
+        # Embeddings.
+        if self.pre_process:
+            logging.trace(
+                f"In TransformerLanguageModel() enter Embedding()", trace_type="recovery_time")
+            self.embedding = Embedding(
+                hidden_size=self.hidden_size,
+                vocab_size=self.vocab_size,
+                max_sequence_length=self.max_position_embeddings,
+                init_method=self.init_method,
+                num_tokentypes=self.num_tokentypes,
+                use_cpu_initialization=use_cpu_initialization,
+                embedding_dropout_prob=self.hidden_dropout,
+                sequence_parallel=sequence_parallel,
+                position_embedding_type=position_embedding_type,
+                fp32_residual_connection=fp32_residual_connection,
+            )
+            logging.trace(
+                f"In TransformerLanguageModel() leave Embedding()", trace_type="recovery_time")
+            self._embedding_key = 'embedding'
+        # Move Rope to core attention
+        # TODO: check perf penalty vs original Nemo implementation
+        # if position_embedding_type == 'rope':
+        #     rotary_dim = self.hidden_size // num_attention_heads if kv_channels is None else kv_channels
+        #     assert 0 < rotary_percentage <= 1
+        #     if rotary_percentage < 1:
+        #         rotary_dim = int(rotary_dim * rotary_percentage)
+        #     self.rotary_pos_emb = RotaryEmbedding(rotary_dim)
+        # Transformer.
+        logging.trace(
+            f"In TransformerLanguageModel() create encoder begin", trace_type="recovery_time")
+        self.encoder = ParallelTransformer(
+            init_method=self.init_method,
+            output_layer_init_method=self.output_layer_init_method,
+            num_layers=self.num_layers,
+            hidden_size=self.hidden_size,
+            num_attention_heads=num_attention_heads,
+            apply_query_key_layer_scaling=apply_query_key_layer_scaling,
+            kv_channels=kv_channels,
+            ffn_hidden_size=ffn_hidden_size,
+            self_attn_mask_type=self.encoder_attn_mask_type,
+            pre_process=self.pre_process,
+            post_process=self.post_process,
+            precision=precision,
+            fp32_residual_connection=fp32_residual_connection,
+            activations_checkpoint_method=activations_checkpoint_method,
+            activations_checkpoint_num_layers=activations_checkpoint_num_layers,
+            normalization=normalization,
+            layernorm_epsilon=layernorm_epsilon,
+            hidden_dropout=hidden_dropout,
+            attention_dropout=attention_dropout,
+            ffn_dropout=ffn_dropout,
+            use_cpu_initialization=use_cpu_initialization,
+            persist_layer_norm=persist_layer_norm,
+            openai_gelu=openai_gelu,
+            onnx_safe=onnx_safe,
+            bias=bias,
+            bias_activation_fusion=bias_activation_fusion,
+            bias_dropout_add_fusion=bias_dropout_add_fusion,
+            masked_softmax_fusion=masked_softmax_fusion,
+            activation=activation,
+            headscale=headscale,
+            transformer_block_type=transformer_block_type,
+            normalize_attention_scores=normalize_attention_scores,
+            multi_query_attention=True,
+            gradient_accumulation_fusion=gradient_accumulation_fusion,
+            megatron_legacy=megatron_legacy,
+            sequence_parallel=sequence_parallel,
+            activations_checkpoint_granularity=activations_checkpoint_granularity,
+            activations_checkpoint_layers_per_pipeline=activations_checkpoint_layers_per_pipeline,
+            transformer_engine=transformer_engine,
+            fp8=fp8,
+            fp8_e4m3=fp8_e4m3,
+            fp8_hybrid=fp8_hybrid,
+            fp8_margin=fp8_margin,
+            fp8_interval=fp8_interval,
+            fp8_amax_history_len=fp8_amax_history_len,
+            fp8_amax_compute_algo=fp8_amax_compute_algo,
+            reduce_amax=reduce_amax,
+            use_emha=use_emha,
+            position_embedding_type=self.position_embedding_type,
+            position_interpolation_factor=self.position_interpolation_factor,
+            max_position_embeddings=self.max_position_embeddings,
+            rotary_percentage=self.rotary_percentage,
+        )
+        logging.trace(
+            f"In TransformerLanguageModel() create encoder done", trace_type="recovery_time")
+        self._encoder_key = 'encoder'
+
+        # Decoder
+        if self.add_decoder:
+            self.decoder = ParallelTransformer(
+                layer_type=LayerType.decoder,
+                self_attn_mask_type=self.decoder_attn_mask_type,
+                init_method=self.init_method,
+                output_layer_init_method=self.output_layer_init_method,
+                num_layers=self.num_layers,
+                hidden_size=self.hidden_size,
+                num_attention_heads=num_attention_heads,
+                apply_query_key_layer_scaling=apply_query_key_layer_scaling,
+                kv_channels=kv_channels,
+                ffn_hidden_size=ffn_hidden_size,
+                pre_process=self.pre_process,
+                post_process=self.post_process,
+                precision=precision,
+                fp32_residual_connection=fp32_residual_connection,
+                activations_checkpoint_method=activations_checkpoint_method,
+                activations_checkpoint_num_layers=activations_checkpoint_num_layers,
+                normalization=normalization,
+                layernorm_epsilon=layernorm_epsilon,
+                hidden_dropout=hidden_dropout,
+                attention_dropout=attention_dropout,
+                use_cpu_initialization=use_cpu_initialization,
+                bias_activation_fusion=bias_activation_fusion,
+                bias_dropout_add_fusion=bias_dropout_add_fusion,
+                masked_softmax_fusion=masked_softmax_fusion,
+                gradient_accumulation_fusion=gradient_accumulation_fusion,
+                persist_layer_norm=persist_layer_norm,
+                openai_gelu=openai_gelu,
+                onnx_safe=onnx_safe,
+                megatron_legacy=megatron_legacy,
+                sequence_parallel=sequence_parallel,
+                activations_checkpoint_granularity=activations_checkpoint_granularity,
+                activations_checkpoint_layers_per_pipeline=activations_checkpoint_layers_per_pipeline,
+                transformer_engine=transformer_engine,
+                position_interpolation_factor=self.position_interpolation_factor,
+                max_position_embeddings=self.max_position_embeddings,
+                rotary_percentage=self.rotary_percentage,
+            )
+            self._decoder_key = 'decoder'
+
+        if self.post_process:
+            # Pooler.
+            if self.add_pooler:
+                self.pooler = Pooler(
+                    self.hidden_size, self.init_method, sequence_parallel=sequence_parallel)
+                self._pooler_key = 'pooler'
+
+            if not self.share_embeddings_and_output_weights:
+                no_async_tensor_model_parallel_allreduce = (
+                    parallel_state.get_tensor_model_parallel_world_size() == 1 or sequence_parallel
+                )
+                self.output_layer = tensor_parallel.ColumnParallelLinear(
+                    self.hidden_size,
+                    self.vocab_size,
+                    # Setting bias to False always to keep it consistent with embedding tying that also does not have a bias.
+                    bias=False,
+                    init_method=self.init_method,
+                    skip_bias_add=True,
+                    use_cpu_initialization=use_cpu_initialization,
+                    gather_output=False,
+                    sequence_parallel_enabled=sequence_parallel,
+                    no_async_tensor_model_parallel_allreduce=no_async_tensor_model_parallel_allreduce,
+                    gradient_accumulation_fusion=gradient_accumulation_fusion,
+                    transfer_with_static_ring=(
+                        not (activations_checkpoint_granularity == "selective")),
+                )
+                self._output_layer_key = 'output_layer'
+
+    def set_input_tensor(self, input_tensor):
+        """ See megatron.model.transformer.set_input_tensor()"""
+        # This is usually handled in schedules.py but some inference code still
+        # gives us non-lists or None
+        if not isinstance(input_tensor, list):
+            input_tensor = [input_tensor]
+
+        self.encoder.set_input_tensor(input_tensor[0])
+
+    def forward(
+        self,
+        enc_input_ids,
+        enc_position_ids,
+        enc_attn_mask,
+        dec_input_ids=None,
+        dec_position_ids=None,
+        dec_attn_mask=None,
+        enc_dec_attn_mask=None,
+        token_type_ids=None,
+        layer_past=None,
+        get_key_value=False,
+        pooling_sequence_index=0,
+        enc_hidden_states=None,
+        output_enc_hidden_only=False,
+        encoder_input=None,
+        set_inference_key_value_memory=False,
+        inference_max_sequence_len=None,
+        checkpoint_activations_all_layers=None,
+    ):
+        # Embeddings.
+        if self.pre_process and encoder_input is None:
+            encoder_input = self.embedding(
+                enc_input_ids, enc_position_ids, token_type_ids=token_type_ids)
+        else:
+            pass
+
+        # encoder_input: [s, b, h]
+
+        # enc_attn_mask: [1, 1, s, s]
+        # Move rope to core attention
+        # if self.position_embedding_type == 'rope':
+        #     if inference_max_sequence_len is not None:
+        #         rotary_pos_emb = self.rotary_pos_emb(inference_max_sequence_len)
+        #     elif self.encoder.input_tensor is not None:
+        #         if self.sequence_parallel:
+        #             rotary_pos_emb = self.rotary_pos_emb(
+        #                 self.encoder.input_tensor.size(0) * parallel_state.get_tensor_model_parallel_world_size()
+        #             )
+        #         else:
+        #             rotary_pos_emb = self.rotary_pos_emb(self.encoder.input_tensor.size(0))
+        #     else:
+        #         if self.sequence_parallel:
+        #             rotary_pos_emb = self.rotary_pos_emb(
+        #                 encoder_input.size(0) * parallel_state.get_tensor_model_parallel_world_size()
+        #             )
+        #         else:
+        #             rotary_pos_emb = self.rotary_pos_emb(encoder_input.size(0))
+        rotary_pos_emb = None
+        # encoder.
+        if enc_hidden_states is None:
+            encoder_output = self.encoder(
+                encoder_input,
+                enc_attn_mask,
+                layer_past=layer_past,
+                get_key_value=get_key_value,
+                set_inference_key_value_memory=set_inference_key_value_memory,
+                inference_max_sequence_len=inference_max_sequence_len,
+                checkpoint_activations_all_layers=checkpoint_activations_all_layers,
+                rotary_pos_emb=(rotary_pos_emb, None, None)
+                if rotary_pos_emb is not None
+                # This assumes that this being used as a GPT/BERT model only (no cross-attention)
+                else None,
+            )
+        else:
+            encoder_output = enc_hidden_states.to(encoder_input.dtype)
+
+        if self.post_process:
+            if not self.share_embeddings_and_output_weights:
+                encoder_output, _ = self.output_layer(encoder_output)
+            if self.add_pooler:
+                pooled_output = self.pooler(
+                    encoder_output, pooling_sequence_index)
+
+        # output_enc_hidden_only refers to when we just need the encoder's
+        # output. For example, it is helpful to compute
+        # similarity between two sequences by average pooling
+        if not self.add_decoder or output_enc_hidden_only:
+            if self.add_pooler and self.post_process:
+                return encoder_output, pooled_output
+            else:
+                return encoder_output
+
+        # Decoder Embedding
+        dec_embedding_output = self.embedding(dec_input_ids, dec_position_ids)
+        # decoder
+        decoder_output = self.decoder(
+            dec_embedding_output,
+            dec_attn_mask,
+            layer_past=layer_past,
+            get_key_value=get_key_value,
+            encoder_output=encoder_output,
+            enc_dec_attn_mask=enc_dec_attn_mask,
+            set_inference_key_value_memory=set_inference_key_value_memory,
+            inference_max_sequence_len=inference_max_sequence_len,
+            checkpoint_activations_all_layers=checkpoint_activations_all_layers,
+        )
+
+        if self.add_pooler and self.post_process:
+            return decoder_output, encoder_output, pooled_output
+        else:
+            return decoder_output, encoder_output
+
+    def state_dict_for_save_checkpoint(self, destination=None, prefix='', keep_vars=False):
+        """For easy load."""
+
+        state_dict_ = {}
+        if self.pre_process:
+            state_dict_[self._embedding_key] = self.embedding.state_dict_for_save_checkpoint(
+                destination, prefix, keep_vars
+            )
+
+        state_dict_[self._encoder_key] = self.encoder.state_dict_for_save_checkpoint(
+            destination, prefix, keep_vars)
+        if self.post_process:
+            if self.add_pooler:
+                state_dict_[self._pooler_key] = self.pooler.state_dict_for_save_checkpoint(
+                    destination, prefix, keep_vars
+                )
+        if self.add_decoder:
+            state_dict_[self._decoder_key] = self.decoder.state_dict_for_save_checkpoint(
+                destination, prefix, keep_vars
+            )
+
+        return state_dict_
+
+    def load_state_dict(self, state_dict, strict=True):
+        """Customized load."""
+
+        # Embedding.
+        if self.pre_process:
+            if self._embedding_key in state_dict:
+                state_dict_ = state_dict[self._embedding_key]
+            else:
+                # for backward compatibility.
+                state_dict_ = {}
+                for key in state_dict.keys():
+                    if '_embeddings' in key:
+                        state_dict_[key] = state_dict[key]
+            self.embedding.load_state_dict(state_dict_, strict=strict)
+
+        # Encoder.
+        if self._encoder_key in state_dict:
+            state_dict_ = state_dict[self._encoder_key]
+
+        # for backward compatibility.
+        elif 'transformer' in state_dict:
+            state_dict_ = state_dict['transformer']
+        else:
+            # for backward compatibility.
+            state_dict_ = {}
+            for key in state_dict.keys():
+                if 'transformer.' in key:
+                    state_dict_[key.split('transformer.')[1]] = state_dict[key]
+
+        # for backward compatibility.
+        state_dict_self_attention = {}
+        for key in state_dict_.keys():
+            if '.attention.' in key:
+                state_dict_self_attention[key.replace(
+                    ".attention.", ".self_attention.")] = state_dict_[key]
+            else:
+                state_dict_self_attention[key] = state_dict_[key]
+        state_dict_ = state_dict_self_attention
+
+        self.encoder.load_state_dict(state_dict_, strict=strict)
+
+        if self.post_process:
+            # pooler
+            if self.add_pooler:
+                assert 'pooler' in state_dict, 'could not find data for pooler in the checkpoint'
+                self.pooler.load_state_dict(
+                    state_dict[self._pooler_key], strict=strict)
+
+            if not self.share_embeddings_and_output_weights:
+                self.output_layer.load_state_dict(
+                    state_dict[self._output_layer_key], strict=strict)
+        # decoder
+        if self.add_decoder:
+            assert 'decoder' in state_dict, 'could not find data for pooler in the checkpoint'
+            self.decoder.load_state_dict(
+                state_dict[self._decoder_key], strict=strict)
+
+
+def get_bigcode_language_model(
+    hidden_size,
+    ffn_hidden_size,
+    num_layers,
+    max_position_embeddings,
+    num_tokentypes,
+    add_pooler,
+    vocab_size,
+    num_attention_heads,
+    encoder_attn_mask_type,
+    apply_query_key_layer_scaling=True,
+    kv_channels=None,
+    init_method=None,
+    scaled_init_method=None,
+    add_decoder=False,
+    decoder_attn_mask_type=AttnMaskType.causal,
+    pre_process=True,
+    post_process=True,
+    init_method_std=0.02,
+    use_cpu_initialization=False,
+    hidden_dropout=0.1,
+    attention_dropout=0.1,
+    ffn_dropout=0.0,
+    precision=16,
+    fp32_residual_connection=False,
+    activations_checkpoint_method=None,
+    activations_checkpoint_num_layers=1,
+    normalization='layernorm',
+    layernorm_epsilon=1e-5,
+    bias_activation_fusion=True,
+    masked_softmax_fusion=True,
+    activation='gelu',
+    headscale=False,
+    transformer_block_type='pre_ln',
+    normalize_attention_scores=True,
+    position_embedding_type='learned_absolute',
+    attention_type='multihead',
+    share_embeddings_and_output_weights=True,
+    rotary_percentage=1.0,
+    bias_dropout_add_fusion=True,
+    bias=True,
+    gradient_accumulation_fusion=False,
+    persist_layer_norm=False,
+    openai_gelu=False,
+    onnx_safe=False,
+    megatron_legacy=False,
+    activations_checkpoint_granularity=None,
+    activations_checkpoint_layers_per_pipeline=None,
+    sequence_parallel=False,
+    transformer_engine=False,
+    fp8=False,
+    fp8_e4m3=False,
+    fp8_hybrid=False,
+    fp8_margin=0,
+    fp8_interval=1,
+    fp8_amax_history_len=1,
+    fp8_amax_compute_algo='most_recent',
+    reduce_amax=True,
+    use_emha=False,
+    position_interpolation_factor=1.0,
+):
+    """Build language model and return along with the key to save."""
+
+    if kv_channels is None:
+        assert (
+            hidden_size % num_attention_heads == 0
+        ), 'hidden_size must be divisible by num_attention_heads if kv_channels is None'
+        kv_channels = hidden_size // num_attention_heads
+
+    if init_method is None:
+        init_method = init_method_normal(init_method_std)
+
+    if scaled_init_method is None:
+        scaled_init_method = scaled_init_method_normal(
+            init_method_std, num_layers)
+
+    logging.trace(f"In get_language_model() enter TransformerLanguageModel()",
+                  trace_type="recovery_time")
+    # Language model.
+    language_model = TransformerLanguageModel(
+        init_method=init_method,
+        output_layer_init_method=scaled_init_method,
+        encoder_attn_mask_type=encoder_attn_mask_type,
+        num_tokentypes=num_tokentypes,
+        vocab_size=vocab_size,
+        max_position_embeddings=max_position_embeddings,
+        hidden_size=hidden_size,
+        num_layers=num_layers,
+        num_attention_heads=num_attention_heads,
+        apply_query_key_layer_scaling=apply_query_key_layer_scaling,
+        kv_channels=kv_channels,
+        ffn_hidden_size=ffn_hidden_size,
+        add_decoder=add_decoder,
+        decoder_attn_mask_type=decoder_attn_mask_type,
+        add_pooler=add_pooler,
+        pre_process=pre_process,
+        post_process=post_process,
+        use_cpu_initialization=use_cpu_initialization,
+        hidden_dropout=hidden_dropout,
+        attention_dropout=attention_dropout,
+        ffn_dropout=ffn_dropout,
+        precision=precision,
+        fp32_residual_connection=fp32_residual_connection,
+        activations_checkpoint_method=activations_checkpoint_method,
+        activations_checkpoint_num_layers=activations_checkpoint_num_layers,
+        normalization=normalization,
+        layernorm_epsilon=layernorm_epsilon,
+        bias_activation_fusion=bias_activation_fusion,
+        bias_dropout_add_fusion=bias_dropout_add_fusion,
+        bias=bias,
+        rotary_percentage=rotary_percentage,
+        share_embeddings_and_output_weights=share_embeddings_and_output_weights,
+        masked_softmax_fusion=masked_softmax_fusion,
+        gradient_accumulation_fusion=gradient_accumulation_fusion,
+        activation=activation,
+        headscale=headscale,
+        transformer_block_type=transformer_block_type,
+        normalize_attention_scores=normalize_attention_scores,
+        position_embedding_type=position_embedding_type,
+        persist_layer_norm=persist_layer_norm,
+        openai_gelu=openai_gelu,
+        onnx_safe=onnx_safe,
+        megatron_legacy=megatron_legacy,
+        activations_checkpoint_granularity=activations_checkpoint_granularity,
+        activations_checkpoint_layers_per_pipeline=activations_checkpoint_layers_per_pipeline,
+        sequence_parallel=sequence_parallel,
+        transformer_engine=transformer_engine,
+        fp8=fp8,
+        fp8_e4m3=fp8_e4m3,
+        fp8_hybrid=fp8_hybrid,
+        fp8_margin=fp8_margin,
+        fp8_interval=fp8_interval,
+        fp8_amax_history_len=fp8_amax_history_len,
+        fp8_amax_compute_algo=fp8_amax_compute_algo,
+        reduce_amax=reduce_amax,
+        use_emha=use_emha,
+        position_interpolation_factor=position_interpolation_factor,
+    )
+    logging.trace(f"In get_language_model() leave TransformerLanguageModel()",
+                  trace_type="recovery_time")
+
+    # key used for checkpoints.
+    language_model_key = 'language_model'
+
+    return language_model, language_model_key
+
+
+def get_dropout_add(training):
+    def _dropout_add(x, bias, residual, prob):
+        assert bias is None
+        return dropout_add(x, bias, residual, prob, training)
+
+    return _dropout_add
+
+
+def get_bias_dropout_add(training):
+    def _bias_dropout_add(x, bias, residual, prob):
+        return bias_dropout_add(x, bias, residual, prob, training)
+
+    return _bias_dropout_add


### PR DESCRIPTION
This PR adds support for training/fine-tuning BigCode family of models (ie.: starcoder, starcoderbase-7b, etc). The multi-query implementation follows the BigCode fork of Megatron (instead of Llama's GQA, they only support a single KV channel and that single channel is replicated across the TP workers).

Below, is a tutorial for anyone willing to use it based on the Code Parrot dataset.

# Code Parrot example

## Getting Started

First download the code parrot dataset
```bash
mkdir -p $HOME/examples_datasets/starcoder
cd $HOME/examples_datasets/starcoder
git clone https://huggingface.co/datasets/codeparrot/codeparrot-clean
cd codeparrot-clean/
git lfs fetch --all && git lfs pull
cd ..
git clone https://huggingface.co/bigcode/starcoder starcoder_model
```

Then from `neuronx-nemo-megatron`:
```bash
python ./nemo/scripts/nlp_language_modeling/preprocess_data_for_megatron.py --preproc-folder \
--input $HOME/examples_datasets/starcoder/codeparrot-clean/ --tokenizer-library huggingface --tokenizer-type \
$HOME/examples_datasets/starcoder/starcoder_model/ --workers 8 --output-prefix \
$HOME/examples_datasets/starcoder/codeparrot-clean-mmap --json-keys=content
```

## Model Compilation
On Slurm:
```bash
sbatch -C trn1.32xlarge --nodes 4 compile.slurm starcoder_7b.sh
```

## Model Training
On Slurm:
```bash
sbatch -C trn1.32xlarge --nodes 4 run.slurm starcoder_7b.sh
```

## Fine-tunning starcoderbase-7b
### Download HF Checkpoint
```bash
cd $HOME/examples_datasets/starcoder
git clone https://huggingface.co/bigcode/starcoderbase-7b
cd starcoderbase-7b && git lfs fetch --all && git lfs pull
```

### Convert HF Checkpoint Format to NeMo
```bash
python ./examples/nlp/language_modeling/checkpoint_conversion/convert_hf_checkpoint_to_nemo_bigcode.py \
--path_to_checkpoint $HOME/examples_datasets/starcoder/starcoderbase-7b/ \
--path_to_tokenizer $HOME/examples_datasets/starcoder/starcoderbase-7b/ \
--config_file $HOME/examples_datasets/starcoder/starcoderbase-7b/config.json \
--output_path $HOME/examples_datasets/starcoder/starcoderbase-7b_nemo_tp_8_pp_2 \
--tp_degree 8 \
--pp_degree 2
```

### Add Reference to NeMo Checkpoint in Training Script
Copy paste the full path of the first shard into `test_bigcode.sh`. Then, configure the `load_xser`, `resume_from_checkpoint` and `use_cpu_initialization` as recommended. It should look like:
```bash
model.resume_from_checkpoint=$HOME/examples_datasets/starcoder/starcoderbase-7b_nemo_tp_8_pp_2/tp_rank_00_pp_rank_000/model_optim_rng.ckpt \
model.use_cpu_initialization=False \
+model.load_xser=True \
```

### Convert NeMo Checkpoint to HF
```bash
python ./examples/nlp/language_modeling/checkpoint_conversion/convert_nemo_checkpoint_to_hf_bigcode.py \
 --path_to_checkpoints ./examples/nlp/language_modeling/nemo_experiments/megatron_bigcode/184/checkpoints/ \
--config_file $HOME/examples_datasets/starcoder/starcoderbase-7b/config.json \
--output_path $HOME/examples_datasets/starcoder/starcoderbase-7b-codeparrot \
--is_xser True
```