### PR TITLE
bugfix: inv_freq buffer in Llama RotaryEmbedding shouldn't be persistent

### DIFF
--- a/nemo/nemo/collections/nlp/modules/common/megatron/llama_module.py
+++ b/nemo/nemo/collections/nlp/modules/common/megatron/llama_module.py
@@ -100,7 +100,7 @@ class RotaryEmbedding(torch.nn.Module):
     def __init__(self, dim, max_position_embeddings=4096, base=10000, device=None):
         super().__init__()
         inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2).float() / dim))
-        self.register_buffer("inv_freq", inv_freq)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
 
         # Build here to make `torch.jit.trace` work.
         self.max_seq_len_cached = max_position_embeddings


### PR DESCRIPTION
* In a more recent version of Transformers, inv_freq buffer is no longer persistent https://github.com/huggingface/transformers/commit/95f96b45ffb57291c69a43d7a11a5bb166220d0b
* This causes a crash when someone tries to load a (converted) Llama checkpoint in NeMo (ie.: CodeLlama 7b)

*Issue #, if available: N/A

Description of changes: Switches off persistent flag when registering inv_freq buffer


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
