### PR TITLE
Makes Llama checkpoint convertion compatible with fused up/gate projection

### DIFF
--- a/nemo/examples/nlp/language_modeling/checkpoint_conversion/convert_hf_checkpoint_to_nemo_llama.py
+++ b/nemo/examples/nlp/language_modeling/checkpoint_conversion/convert_hf_checkpoint_to_nemo_llama.py
@@ -47,8 +47,7 @@ def convert_checkpoint(p):
         "self_attention.dense.weight": (1, "self_attn.o_proj.weight", 1, 0),
         "post_attention_layernorm.weight": (0, "post_attention_layernorm.weight", None, 0),
         "self_attention.core_attention.rotary_emb.inv_freq": (0, "self_attn.rotary_emb.inv_freq", None, 0),
-        "mlp.dense_h_to_4h.weight": (1, "mlp.gate_proj.weight", 0, 0),
-        "mlp.dense_h_to_4h_2.weight": (1, "mlp.up_proj.weight", 0, 0),
+        "mlp.dense_h_to_4h.weight": (1, "mlp.gate_proj_up_proj.weight", 0, 0),
         "mlp.dense_4h_to_h.weight": (1, "mlp.down_proj.weight", 1, 0),
         "model.language_model.encoder.final_layernorm.weight": (0, "model.norm.weight", None, 0),
         "model.language_model.output_layer.weight": (1, "lm_head.weight", 0, 0),
@@ -78,9 +77,15 @@ def convert_checkpoint(p):
         v = model_llama[f'model.layers.{i}.self_attn.v_proj.weight']
         model_llama[f'model.layers.{i}.self_attn.query_key_value.weight'] = torch.cat([q, k, v], dim=0)
 
+        gate_proj = model_llama[f'model.layers.{i}.mlp.gate_proj.weight']
+        up_proj = model_llama[f'model.layers.{i}.mlp.up_proj.weight']
+        model_llama[f'model.layers.{i}.mlp.gate_proj_up_proj.weight'] = torch.cat([gate_proj, up_proj], dim=0)
+
         model_llama.pop(f'model.layers.{i}.self_attn.q_proj.weight')
         model_llama.pop(f'model.layers.{i}.self_attn.k_proj.weight')
         model_llama.pop(f'model.layers.{i}.self_attn.v_proj.weight')
+        model_llama.pop(f'model.layers.{i}.mlp.gate_proj.weight')
+        model_llama.pop(f'model.layers.{i}.mlp.up_proj.weight')
 
     for p in range(PP):
         for i in range(TP):

--- a/nemo/nemo/collections/nlp/parts/serialization.py
+++ b/nemo/nemo/collections/nlp/parts/serialization.py
@@ -102,7 +102,7 @@ def save(data, path, should_save=True, partition=0, num_partitions=1, saver=None
       Default: False
   """
   if saver is None:
-      saver = SimplerSaver()
+      saver = SimpleSaver()
   ref_data = _rewrite_data(_get_tensors_folder(path), data, should_save, partition, num_partitions, saver)
   if should_save:
     saver.add_save_task(ref_data, path)


### PR DESCRIPTION
Issue #, [24](https://github.com/aws-neuron/neuronx-nemo-megatron/issues/24)

Description of changes:

Recent merging of up/down projection in Llama requires the equivalent merging in the HF to NeMo conversion scripts (and subsequent splitting in the NeMo to HF script).

This change fixes that for the following converters:

- convert_nemo_checkpoint_to_hf_llama.py
- convert_hf_checkpoint_to_nemo_llama.py
- convert_hf_checkpoint_to_nemo_llama_70b.py

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
