### PR TITLE
Fix class name

### DIFF
--- a/nemo/nemo/collections/nlp/parts/serialization.py
+++ b/nemo/nemo/collections/nlp/parts/serialization.py
@@ -102,7 +102,7 @@ def save(data, path, should_save=True, partition=0, num_partitions=1, saver=None
       Default: False
   """
   if saver is None:
-      saver = SimplerSaver()
+      saver = SimpleSaver()
   ref_data = _rewrite_data(_get_tensors_folder(path), data, should_save, partition, num_partitions, saver)
   if should_save:
     saver.add_save_task(ref_data, path)


### PR DESCRIPTION
*Issue #, if available:* #25

*Description of changes:*

In [serialization.py](https://github.com/aws-neuron/neuronx-nemo-megatron/blob/main/nemo/nemo/collections/nlp/parts/serialization.py#L105)

`saver = SimplerSaver()`

changed to

`saver = SimpleSaver()`
