### PR TITLE
Added a fix for nodelst helper

### DIFF
--- a/k8s/docker/nodelist_helper.py
+++ b/k8s/docker/nodelist_helper.py
@@ -4,17 +4,19 @@
 #   and the OMPI world size
 import re
 import os
-##os.environ['PMIX_HOSTNAME'] = "test-mpi-dumpenv-worker-1"
-##os.environ['OMPI_COMM_WORLD_SIZE'] = "2"
-this_host = os.environ.get("PMIX_HOSTNAME", "")
-s = re.search(r"^(.*-worker)-\d+", this_host)
-if not s:
+import subprocess
+
+if not os.environ.get("PMIX_HOSTNAME"):
     raise Exception("Error: This script should be run via mpirun on EKS")
+
+this_host = subprocess.check_output(["hostname", "--fqdn"]).decode().strip()
+s = re.search(r"^(.*-worker)-\d+(.*)", this_host)
 host_prefix = s.group(1)
-world_size = int(os.environ.get("OMPI_COMM_WORLD_SIZE", "0"))
+host_suffix = s.group(2)
+world_size = int(os.environ.get("OMPI_COMM_WORLD_SIZE", "1"))
 
 hosts = []
 for x in range(world_size):
-    hosts.append(f"{host_prefix}-{x}.{host_prefix}.default.svc")
+    hosts.append(f"{host_prefix}-{x}{host_suffix}")
 
 print(" ".join(hosts))


### PR DESCRIPTION
Able to run with the fix suggested by @5cp. Referring to https://code.amazon.com/packages/Neuron-Nemo-Megatron/blobs/mainline/--/k8s/docker/nodelist_helper.py

```
Loss=3.920, gradient_norm=1.070, parameter_norm=1536.0, global_step=563.0, consumed_samples=1.44e+5, throughput=19.00, Epoch 0:   3%|▎         | 565/20101 [2:12:19<76:15:08, 14.05s/it, loss=nan, v_num=, val_loss_step=11.30, reduced_train_loss=3.910, gradient_norm=1.010, parameter_norm=1552.0, global_step=564.0, consumed_samples=1.45e+5, throughput=19.00, Epoch 0:   3%|▎         | 566/20101 [2:12:32<76:14:33, 14.05s/it, loss=nan, v_num=, val_loss_step=11.30, reduced_train_loss=3.910, gradient_norm=1.010, parameter_norm=1552.0, global_step=564.0, consumed_samples=1.45e+5, throughput=19.00, Epoch 0:   3%|▎         | 566/20101 [2:12:32<76:14:33, 14.05s/it, loss=nan, v_num=, val_loss_step=11.30, reduced_train_loss=4.000, gradient_norm=1.010, parameter_norm=1544.0, global_step=565.0, consumed_samples=1.45e+5, throughput=19.00, Epoch 0:   3%|▎         | 567/20101 [2:12:45<76:14:00, 14.05s/it, loss=nan, v_num=, val_loss_step=11.30, reduced_train_loss=4.000, gradient_norm=1.010, parameter_norm=1544.0, global_step=565.0, consumed_samples=1.45e+5, throughput=19.00, Epoch 0:   3%|▎         | 567/20101 [2:12:45<76:14:00, 14.05s/it, loss=nan, v_num=, val_loss_step=11.30, reduced_train_loss=3.940, gradient_norm=0.996, parameter_norm=1544.0, global_step=566.0, consumed_samples=1.45e+5, throughput=19.00, Epoch 0:   3%|▎         | 568/20101 [2:12:59<76:13:27, 14.05s/it, loss=nan, v_num=, val_loss_step=11.30, reduced_train_loss=3.940, gradient_norm=0.996, parameter_norm=1544.0, global_step=566.0, consumed_samples=1.45e+5, throughput=19.00, Epoch 0:   3%|▎         | 568/20101 [2:12:59<76:13:27, 14.05s/it, loss=nan, v_num=, val_loss_step=11.30, reduced_train_loss=3.950, gradient_norm=1.110, parameter_norm=1544.0, global_step=567.0, consumed_samples=1.45e+5, throughput=19.00, Epoch 0:   3%|▎         | 569/20101 [2:13:12<76:12:54, 14.05s/it, loss=nan, v_num=, val_loss_step=11.30, reduced_train_loss=3.950, gradient_norm=1.110, parameter_norm=1544.0, global_step=567.0, consumed_samples=1.45e+5, throughput=19.00, Epoch 0:   3%|▎         | 569/20101 [2:13:12<76:12:54, 14.05s/it, loss=nan, v_num=, val_loss_step=11.30, reduced_train_loss=3.940, gradient_norm=1.010, parameter_norm=1536.0, global_step=568.0, consumed_samples=1.46e+5, throughput=19.00, Epoch 0:   3%|▎         | 570/20101 [2:13:26<76:12:20, 14.05s/it, loss=nan, v_num=, val_loss_step=11.30, reduced_train_loss=3.940, gradient_norm=1.010, parameter_norm=1536.0, global_step=568.0, consumed_samples=1.46e+5, throughput=19.00, Epoch 0:   3%|▎         | 570/20101 [2:13:26<76:12:20, 14.05s/it, loss=nan, v_num=, val_loss_step=11.30, reduced_train_
```